### PR TITLE
Plugin updates and resource optimization

### DIFF
--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -215,7 +215,8 @@ def get_plugin_args(
         pl_assembly = f"_{assembly}" if species == "homo_sapiens" else ""
         file = os.path.join(plugin_data_dir, f"Phenotypes_data_files/Phenotypes.pm_{species}_{version}{pl_assembly}.gvf.gz")
         
-        check_plugin_files(plugin, [file], "skip")
+        if check_plugin_files(plugin, [file], "skip") is None:
+            return None
             
         return f"Phenotypes,file={file},id_match=1,cols=phenotype&source&id&type&clinvar_clin_sig"
         
@@ -239,14 +240,16 @@ def get_plugin_args(
     if plugin == "Conservation":
         file = os.path.join(conservation_data_dir, f"gerp_conservation_scores.{species}.{assembly}.bw")
         
-        check_plugin_files(plugin, [file], "skip")
+        if check_plugin_files(plugin, [file], "skip") is None:
+            return None
             
         return f"Conservation,{file}"
     
     if plugin == "MaveDB":
         file = os.path.join(plugin_data_dir, "MaveDB_variants.tsv.gz")
         
-        check_plugin_files(plugin, [file], "skip")
+        if check_plugin_files(plugin, [file], "skip") is None:
+            return None
             
         return f"MaveDB,file={file},cols=MaveDB_score:MaveDB_urn,transcript_match=1"
     
@@ -256,7 +259,8 @@ def get_plugin_args(
             plugin_data_dir = plugin_data_dir.replace(f"{version}", "111")
         file = os.path.join(plugin_data_dir, "AlphaMissense_hg38.tsv.gz")
         
-        check_plugin_files(plugin, [file], "skip")
+        if check_plugin_files(plugin, [file], "skip") is None:
+            return None
             
         return f"AlphaMissense,file={file}"
 
@@ -267,7 +271,8 @@ def get_plugin_args(
         file_name = "ClinPred_hg38_sorted_tabbed.tsv.gz" if assembly == "GRCh38" else "ClinPred_tabbed.tsv.gz"
         file = os.path.join(plugin_data_dir, "ClinPred", file_name)
         
-        check_plugin_files(plugin, [file], "skip")
+        if check_plugin_files(plugin, [file], "skip") is None:
+            return None
             
         return f"ClinPred,file={file}"
 

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -157,8 +157,8 @@ def format_gnomad_args(source: str, metadata: dict) -> str:
         if not os.path.isfile(file):
             print(f"[ERROR] Frequency file does not exist - {file}. Exiting ...")
             exit(1)
-        
-        custom_line = f"custom file={file},short_name={source},format=vcf,type=exact,coords=0,fields=GNOMAD_CUSTOM_FIELDS[{source}]"
+
+        custom_line = f"custom file={file},short_name={source},format=vcf,type=exact,coords=0,fields={GNOMAD_CUSTOM_FIELDS[source]}"
         gnomAD_custom_args.append(custom_line)
 
     return "\n".join(gnomAD_custom_args)
@@ -169,18 +169,15 @@ def get_frequency_args(species: str, assembly: str) -> str:
         if source.startswith("gnomAD"):
             if assembly in FREQUENCIES[source]:
                 frequencies.append(format_gnomad_args(source, FREQUENCIES[source][assembly]))
-        elif source.startswith("HPRCs"):
-            # add gnomAD frequency for HPRC assembly (other than T2T)
-            if species.startswith("homo_sapiens_gca"):
+            elif species.startswith("homo_sapiens_gca"):
+                # add gnomAD frequency for HPRC assembly (other than T2T)
                 metadata = FREQUENCIES[source]["HPRCs"]
                 assembly_acc =  species.split("_")[2].replace("gca", "GCA_").replace("v", ".")
                 file = os.path.join(metadata["directory"].replace("##ASSEMBLY##", assembly_acc), metadata["file_pattern"].replace("##ASSEMBLY##", assembly_acc))
-                
-                if not os.file.exists(file):
-                    continue
 
-                custom_line = f"custom file={file},short_name={source},format=vcf,type=exact,coords=0,fields=GNOMAD_CUSTOM_FIELDS[{source}]"
-                frequencies.append(custom_line)
+                if os.path.exists(file):
+                    custom_line = f"custom file={file},short_name={source},format=vcf,type=exact,coords=0,fields={GNOMAD_CUSTOM_FIELDS[source]}"
+                    frequencies.append(custom_line)
         else:
             frequencies.append(FREQUENCIES[source])
 

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -67,7 +67,7 @@ FREQUENCIES = {
         "GRCh38": {
             "version": "4.1",
             "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/grch38/exomes",
-            "file_pattern": "gnomad.exomes.v4.1.sites.chr##CHR##.vcf.bgz"
+            "file_pattern": "gnomad.exomes.v4.1.sites.chr##CHR##_trimmed.vcf.bgz"
         },
         "GRCh37": {
             "version": "4.1",
@@ -84,7 +84,7 @@ FREQUENCIES = {
         "GRCh38": {
             "version": "4.1",
             "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/grch38/genomes",
-            "file_pattern": "gnomad.genomes.v4.1.sites.chr##CHR##.vcf.bgz"
+            "file_pattern": "gnomad.genomes.v4.1.sites.chr##CHR##_trimmed.vcf.bgz"
         },
         "GRCh37": {
             "version": "4.1",
@@ -181,7 +181,7 @@ def get_plugin_args(
         # CADD have data v1.7 data file from e113
         if version < 113:
             plugin_data_dir = plugin_data_dir.replace(f"{version}", "113")
-        snv = os.path.join(plugin_data_dir, f"CADD_{assembly}_1.7_whole_genome_SNVs.tsv.gz ")
+        snv = os.path.join(plugin_data_dir, f"CADD_{assembly}_1.7_whole_genome_SNVs.tsv.gz")
         indels = os.path.join(plugin_data_dir, f"CADD_{assembly}_1.7_InDels.tsv.gz")
         
         check_plugin_files(plugin, [snv, indels])
@@ -258,7 +258,7 @@ def get_plugin_args(
         if version < 113:
             plugin_data_dir = plugin_data_dir.replace(f"{version}", "113")
         file_name = "ClinPred_hg38_sorted_tabbed.tsv.gz" if assembly == "GRCh38" else "ClinPred_tabbed.tsv.gz"
-        file = os.path.join(plugin_data_dir, file_name)
+        file = os.path.join(plugin_data_dir, "ClinPred", file_name)
         
         check_plugin_files(plugin, [file], "skip")
             

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -171,6 +171,18 @@ def get_frequency_args(species: str, assembly: str) -> str:
         else:
             frequencies.append(FREQUENCIES[source])
 
+    if species == "mus_musculus":
+        files = [
+            "/nfs/production/flicek/ensembl/production/ensemblftp/data_files/vertebrates/mus_musculus/GRCm39/variation_genotype/mgp.v3.snps.sorted.rsIDdbSNPv137.GRCm39.vcf.gz",
+            "/nfs/production/flicek/ensembl/production/ensemblftp/data_files/vertebrates/mus_musculus/GRCm39/variation_genotype/mgp.v3.indels.sorted.rsIDdbSNPv137.GRCm39.vcf.gz"
+        ]
+        source = "MGP"
+        fields = "AC%AN"
+
+        for file in files:
+            custom_line = f"custom file={file},short_name={source},format=vcf,type=exact,coords=0,fields={fields}"
+            frequencies.append(custom_line)
+
     return frequencies
     
 def check_plugin_files(plugin: str, files: list, exit_rule: str = "exit") -> bool:
@@ -441,7 +453,7 @@ def main(args = None):
         polyphen = True
     
     frequencies = []
-    if species.startswith("homo_sapiens"):
+    if species.startswith("homo_sapiens") or species == "mus_musculus":
         frequencies = get_frequency_args(species, assembly)
         
     plugins = get_plugins(species, version, assembly, repo_dir, conservation_data_dir)

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -153,9 +153,13 @@ def get_frequency_args(assembly: str) -> str:
     
     return frequencies
     
-def check_plugin_files(plugin: str, files: list) -> bool:
+def check_plugin_files(plugin: str, files: list, exit_rule: str = "exit") -> bool:
     for file in files:
         if not os.path.isfile(file):
+            if exit_rule == "skip":
+                print(f"[INFO] Cannot get {plugin} data file - {file}. Skipping ...")
+                return None
+
             print(f"[INFO] Cannot get {plugin} data file - {file}. Exiting ...")
             exit(1)
     
@@ -192,9 +196,7 @@ def get_plugin_args(
         pl_assembly = f"_{assembly}" if species == "homo_sapiens" else ""
         file = os.path.join(plugin_data_dir, f"Phenotypes_data_files/Phenotypes.pm_{species}_{version}{pl_assembly}.gvf.gz")
         
-        if not os.path.isfile(file):
-            print(f"[INFO] Cannot get Phenotype data file - {file}. Skipping ...")
-            return None
+        check_plugin_files(plugin, [file], "skip")
             
         return f"Phenotypes,file={file},id_match=1,cols=phenotype&source&id&type&clinvar_clin_sig"
         
@@ -218,18 +220,14 @@ def get_plugin_args(
     if plugin == "Conservation":
         file = os.path.join(conservation_data_dir, f"gerp_conservation_scores.{species}.{assembly}.bw")
         
-        if not os.path.isfile(file):
-            print(f"[INFO] Cannot get Conservation data file - {file}. Skipping ...")
-            return None
+        check_plugin_files(plugin, [file], "skip")
             
         return f"Conservation,{file}"
     
     if plugin == "MaveDB":
         file = os.path.join(plugin_data_dir, "MaveDB_variants.tsv.gz")
         
-        if not os.path.isfile(file):
-            print(f"[INFO] Cannot get MaveDB data file - {file}. Skipping ...")
-            return None
+        check_plugin_files(plugin, [file], "skip")
             
         return f"MaveDB,file={file},cols=MaveDB_score:MaveDB_urn,transcript_match=1"
     
@@ -239,7 +237,7 @@ def get_plugin_args(
             plugin_data_dir = plugin_data_dir.replace(f"{version}", "111")
         file = os.path.join(plugin_data_dir, "AlphaMissense_hg38.tsv.gz")
         
-        check_plugin_files(plugin, [file])
+        check_plugin_files(plugin, [file], "skip")
             
         return f"AlphaMissense,file={file}"
 

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -181,11 +181,18 @@ def get_plugin_args(
         # CADD have data v1.7 data file from e113
         if version < 113:
             plugin_data_dir = plugin_data_dir.replace(f"{version}", "113")
+
+        if species == "sus_scrofa":
+            snv = os.path.join(plugin_data_dir, f"ALL_pCADD-PHRED-scores.tsv.gz")
+            check_plugin_files(plugin, [snv])
+            
+            return f"CADD,{snv}"
+
         snv = os.path.join(plugin_data_dir, f"CADD_{assembly}_1.7_whole_genome_SNVs.tsv.gz")
         indels = os.path.join(plugin_data_dir, f"CADD_{assembly}_1.7_InDels.tsv.gz")
-        
+
         check_plugin_files(plugin, [snv, indels])
-        
+
         return f"CADD,{snv},{indels}"
     
     if plugin == "REVEL":

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -227,7 +227,9 @@ def get_plugin_args(
     if plugin == "MaveDB":
         file = os.path.join(plugin_data_dir, "MaveDB_variants.tsv.gz")
         
-        check_plugin_files(plugin, [file])
+        if not os.path.isfile(file):
+            print(f"[INFO] Cannot get MaveDB data file - {file}. Skipping ...")
+            return None
             
         return f"MaveDB,file={file},cols=MaveDB_score:MaveDB_urn,transcript_match=1"
     

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -58,7 +58,8 @@ PLUGINS = [
     "Conservation",
     "MaveDB",
     "AlphaMissense",
-    "Downstream"
+    "Downstream",
+    "ClinPred"
 ]
 FREQUENCIES = {
     "1000genomes": "af_1kg 1",
@@ -248,6 +249,17 @@ def get_plugin_args(
         check_plugin_files(plugin, [file], "skip")
             
         return f"AlphaMissense,file={file}"
+
+    if plugin == "ClinPred":
+        # ClinPred do not have data file in e113 directory or below
+        if version < 113:
+            plugin_data_dir = plugin_data_dir.replace(f"{version}", "113")
+        file_name = "ClinPred_hg38_sorted_tabbed.tsv.gz" if assembly == "GRCh38" else "ClinPred_tabbed.tsv.gz"
+        file = os.path.join(plugin_data_dir, file_name)
+        
+        check_plugin_files(plugin, [file], "skip")
+            
+        return f"ClinPred,file={file}"
 
     # some plugin do not need any arguments, for example - Downstream plugin
     return plugin

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -178,8 +178,11 @@ def get_plugin_args(
         plugin_data_dir = plugin_data_dir.replace("grch38", "grch37")
         
     if plugin == "CADD":
-        snv = os.path.join(plugin_data_dir, f"CADD_{assembly}_1.6_whole_genome_SNVs.tsv.gz")
-        indels = os.path.join(plugin_data_dir, f"CADD_{assembly}_1.6_InDels.tsv.gz")
+        # CADD have data v1.7 data file from e113
+        if version < 113:
+            plugin_data_dir = plugin_data_dir.replace(f"{version}", "113")
+        snv = os.path.join(plugin_data_dir, f"CADD_{assembly}_1.7_whole_genome_SNVs.tsv.gz ")
+        indels = os.path.join(plugin_data_dir, f"CADD_{assembly}_1.7_InDels.tsv.gz")
         
         check_plugin_files(plugin, [snv, indels])
         

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -178,10 +178,12 @@ def check_plugin_files(plugin: str, files: list, exit_rule: str = "exit") -> boo
         if not os.path.isfile(file):
             if exit_rule == "skip":
                 print(f"[INFO] Cannot get {plugin} data file - {file}. Skipping ...")
-                return None
+                return False
 
             print(f"[INFO] Cannot get {plugin} data file - {file}. Exiting ...")
             exit(1)
+
+    return True
     
 def get_plugin_args(
         plugin: str, 
@@ -233,7 +235,7 @@ def get_plugin_args(
         pl_assembly = f"_{assembly}" if species == "homo_sapiens" else ""
         file = os.path.join(plugin_data_dir, f"Phenotypes_data_files/Phenotypes.pm_{species}_{version}{pl_assembly}.gvf.gz")
         
-        if check_plugin_files(plugin, [file], "skip") is None:
+        if not check_plugin_files(plugin, [file], "skip"):
             return None
             
         return f"Phenotypes,file={file},id_match=1,cols=phenotype&source&id&type&clinvar_clin_sig"
@@ -258,7 +260,7 @@ def get_plugin_args(
     if plugin == "Conservation":
         file = os.path.join(conservation_data_dir, f"gerp_conservation_scores.{species}.{assembly}.bw")
         
-        if check_plugin_files(plugin, [file], "skip") is None:
+        if not check_plugin_files(plugin, [file], "skip"):
             return None
             
         return f"Conservation,{file}"
@@ -266,7 +268,7 @@ def get_plugin_args(
     if plugin == "MaveDB":
         file = os.path.join(plugin_data_dir, "MaveDB_variants.tsv.gz")
         
-        if check_plugin_files(plugin, [file], "skip") is None:
+        if not check_plugin_files(plugin, [file], "skip"):
             return None
             
         return f"MaveDB,file={file},cols=MaveDB_score:MaveDB_urn,transcript_match=1"
@@ -277,7 +279,7 @@ def get_plugin_args(
             plugin_data_dir = plugin_data_dir.replace(f"{version}", "111")
         file = os.path.join(plugin_data_dir, "AlphaMissense_hg38.tsv.gz")
         
-        if check_plugin_files(plugin, [file], "skip") is None:
+        if not check_plugin_files(plugin, [file], "skip"):
             return None
             
         return f"AlphaMissense,file={file}"
@@ -289,7 +291,7 @@ def get_plugin_args(
         file_name = "ClinPred_hg38_sorted_tabbed.tsv.gz" if assembly == "GRCh38" else "ClinPred_tabbed.tsv.gz"
         file = os.path.join(plugin_data_dir, "ClinPred", file_name)
         
-        if check_plugin_files(plugin, [file], "skip") is None:
+        if not check_plugin_files(plugin, [file], "skip"):
             return None
             
         return f"ClinPred,file={file}"

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -66,35 +66,35 @@ FREQUENCIES = {
     "gnomAD_exomes": {
         "GRCh38": {
             "version": "4.1",
-            "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/exomes",
+            "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/grch38/exomes",
             "file_pattern": "gnomad.exomes.v4.1.sites.chr##CHR##.vcf.bgz"
         },
         "GRCh37": {
             "version": "4.1",
-            "directory": "/hps/nobackup/flicek/ensembl/variation/snhossain/website/gnomad_liftover/remapped/exomes/grch37",
-            "file_pattern": "gnomad.exomes.v4.1.sites.chr##CHR##.liftover_grch38.vcf.gz"
+            "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/grch37/exomes",
+            "file_pattern": "gnomad.exomes.v4.1.sites.grch37.chr##CHR##_trimmed_liftover.vcf.gz"
         },
         "T2T-CHM13v2.0": {
             "version": "4.1",
-            "directory": "/hps/nobackup/flicek/ensembl/variation/snhossain/website/gnomad_liftover/remapped/exomes/T2T-CHM13v2.0",
-            "file_pattern": "gnomad.exomes.v4.1.sites.chr##CHR##.liftover_grch38.vcf.gz"
+            "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/T2T-CHM13v2.0/exomes",
+            "file_pattern": "gnomad.exomes.v4.1.sites.GCA_009914755.4.trimmed_liftover.vcf.gz"
         }
     },
     "gnomAD_genomes": {
         "GRCh38": {
             "version": "4.1",
-            "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/genomes",
+            "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/grch38/genomes",
             "file_pattern": "gnomad.genomes.v4.1.sites.chr##CHR##.vcf.bgz"
         },
         "GRCh37": {
             "version": "4.1",
-            "directory": "/hps/nobackup/flicek/ensembl/variation/snhossain/website/gnomad_liftover/remapped/genomes/grch37",
-            "file_pattern": "gnomad.genomes.v4.1.sites.chr##CHR##.liftover_grch38.vcf.gz"
+            "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/grch37/genomes",
+            "file_pattern": "gnomad.genomes.v4.1.sites.grch37.chr##CHR##_trimmed_liftover.vcf.gz"
         },
         "T2T-CHM13v2.0": {
             "version": "4.1",
-            "directory": "/hps/nobackup/flicek/ensembl/variation/snhossain/website/gnomad_liftover/remapped/genomes/T2T-CHM13v2.0",
-            "file_pattern": "gnomad.genomes.v4.1.sites.chr##CHR##.liftover_grch38.vcf.gz"
+            "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/T2T-CHM13v2.0/genomes",
+            "file_pattern": "gnomad.genomes.v4.1.sites.GCA_009914755.4.trimmed_liftover.vcf.gz"
         }
     }
 }

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -74,11 +74,6 @@ FREQUENCIES = {
             "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/grch37/exomes",
             "file_pattern": "gnomad.exomes.v4.1.sites.grch37.chr##CHR##_trimmed_liftover.vcf.gz"
         },
-        "T2T-CHM13v2.0": {
-            "version": "4.1",
-            "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/T2T-CHM13v2.0/exomes",
-            "file_pattern": "gnomad.exomes.v4.1.sites.GCA_009914755.4.trimmed_liftover.vcf.gz"
-        },
         "HPRCs": {
             "version": "4.1",
             "directory": "/nfs/production/flicek/ensembl/production/ensemblftp/rapid-release/species/Homo_sapiens/##ASSEMBLY##/ensembl/variation/2022_10/vcf/2024_07/",
@@ -95,11 +90,6 @@ FREQUENCIES = {
             "version": "4.1",
             "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/grch37/genomes",
             "file_pattern": "gnomad.genomes.v4.1.sites.grch37.chr##CHR##_trimmed_liftover.vcf.gz"
-        },
-        "T2T-CHM13v2.0": {
-            "version": "4.1",
-            "directory": "/nfs/production/flicek/ensembl/variation/data/gnomAD/v4.1/T2T-CHM13v2.0/genomes",
-            "file_pattern": "gnomad.genomes.v4.1.sites.GCA_009914755.4.trimmed_liftover.vcf.gz"
         },
         "HPRCs": {
             "version": "4.1",

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -50,6 +50,7 @@ POLYPHEN_SPECIES = [
 ]
 PLUGINS = [
     "CADD",
+    "REVEL",
     "SpliceAI",
     "Phenotypes",
     "IntAct",
@@ -182,6 +183,13 @@ def get_plugin_args(
         check_plugin_files(plugin, [snv, indels])
         
         return f"CADD,{snv},{indels}"
+    
+    if plugin == "REVEL":
+        data_file = f"/nfs/production/flicek/ensembl/variation/data/REVEL/2021-may/new_tabbed_revel_{assembly.lower()}.tsv.gz"
+
+        check_plugin_files(plugin, [data_file])
+
+        return f"REVEL,{data_file}"
         
     if plugin == "SpliceAI":
         ucsc_assembly = "hg38" if assembly == "GRCh38" else "hg19"

--- a/nextflow/vcf_prepper/bin/helper.py
+++ b/nextflow/vcf_prepper/bin/helper.py
@@ -143,9 +143,13 @@ def get_ftp_path(
     ) -> str:
     
     version = str(version)
+    if species == "homo_sapiens_37":
+        species = "homo_sapiens"
     
     if mode == "local":
         base = "/nfs/production/flicek/ensembl/production/ensemblftp"
+    elif mode == "remote" and assembly == "GRCh37":
+        base = "ftp.ensembl.org/pub/grch37"
     elif mode == "remote" and division == "EnsemblVertebrates":
         base = "ftp.ensembl.org/pub"
     else:

--- a/nextflow/vcf_prepper/bin/process_cache.py
+++ b/nextflow/vcf_prepper/bin/process_cache.py
@@ -71,11 +71,6 @@ def main(args = None):
             print(f"[INFO] {genome_cache_dir} directory exists. Skipping ...")
             exit(0)
         else:
-            # for human we check and delete cache dir manually if needed - DO NOT OVERWRITE
-            if species.startswith("homo_sapiens"):
-                print(f"[ERROR] {genome_cache_dir} directory exists for human. Won't be overwritten ...")
-                exit(1)
-
             print(f"[INFO] {genome_cache_dir} directory exists. Will be overwritten ...")
             shutil.rmtree(genome_cache_dir)
         

--- a/nextflow/vcf_prepper/bin/process_conservation_data.py
+++ b/nextflow/vcf_prepper/bin/process_conservation_data.py
@@ -58,7 +58,7 @@ def main(args = None):
             print(f"[INFO] {conservation_bw} exists. Skipping ...")
             exit(0)
         else:
-            print(f"[INFO] {conservation_bw} exists. Will be oerwritten ...")
+            print(f"[INFO] {conservation_bw} exists. Will be overwritten ...")
             os.remove(conservation_bw)
         
     src_conservation_bw = get_ftp_path(species, assembly, division, version, "conservation")

--- a/nextflow/vcf_prepper/bin/process_fasta.py
+++ b/nextflow/vcf_prepper/bin/process_fasta.py
@@ -122,8 +122,7 @@ def main(args = None):
     fasta_glob = os.path.join(fasta_dir, f"{fasta_species_name}.{assembly}.dna.*.fa.gz")
 
     fasta = None
-    # for human --force won't work; we check and delete fasta manually if needed 
-    if glob.glob(fasta_glob) and (not args.force or species.startswith("homo_sapiens")):
+    if glob.glob(fasta_glob) and not args.force:
         print(f"[INFO] {fasta_glob} exists. Skipping ...")
         
         fasta = os.path.join(fasta_dir, f"{fasta_species_name}.{assembly}.dna.primary_assembly.fa.gz")

--- a/nextflow/vcf_prepper/bin/process_fasta.py
+++ b/nextflow/vcf_prepper/bin/process_fasta.py
@@ -76,20 +76,20 @@ def index_fasta(zipped_fasta: str, force: str = False) -> None:
         print(f"[ERROR] Cannot index fasta - {fasta} - does not exist. Exiting ...")
         exit(1)
 
-    fai = os.path.join(zipped_fasta, ".fai")
-    gzi = os.path.join(zipped_fasta, ".gzi")
+    fai = zipped_fasta + ".fai"
+    gzi = zipped_fasta + ".gzi"
 
     if os.path.isfile(fai) and os.path.isfile(gzi) and not force:
         print(f"[INFO] both .fai and .gzi file exist. Skipping ...")
         return
 
-    if os.path.isfile(zipped_fasta + ".fai"):
-        print(f"[INFO] {zipped_fasta + '.fai'} exist. Deleting ...")
-        os.remove(zipped_fasta + ".fai")
+    if os.path.isfile(fai):
+        print(f"[INFO] {fai} exist. Deleting ...")
+        os.remove(fai)
     
-    if os.path.isfile(zipped_fasta + ".gzi"):
-        print(f"[INFO] {zipped_fasta + '.gzi'} exist. Deleting ...")
-        os.remove(zipped_fasta + ".gzi")
+    if os.path.isfile(gzi):
+        print(f"[INFO] {gzi} exist. Deleting ...")
+        os.remove(gzi)
     
     cmd_index_fasta = "use Bio::DB::HTS::Faidx;"
     cmd_index_fasta += f"Bio::DB::HTS::Faidx->new('{zipped_fasta}');"

--- a/nextflow/vcf_prepper/bin/process_fasta.py
+++ b/nextflow/vcf_prepper/bin/process_fasta.py
@@ -133,7 +133,7 @@ def main(args = None):
             exit(1)
     else:
         if glob.glob(fasta_glob):
-            print(f"[INFO] {fasta_glob} exists. Will be oerwritten ...")
+            print(f"[INFO] {fasta_glob} exists. Will be overwritten ...")
             for f in glob.glob(fasta_glob):
                 os.remove(f)
         

--- a/nextflow/vcf_prepper/bin/summary_stats.py
+++ b/nextflow/vcf_prepper/bin/summary_stats.py
@@ -122,7 +122,7 @@ def main(args = None):
         for header in HEADERS:
             input_vcf.add_info_to_header(header)
 
-        output_vcf = Writer(output_file, input_vcf, mode="w")
+        output_vcf = Writer(output_file, input_vcf, mode="wz")
     else:
         h_vcf_file = "header.vcf"
         raw_h = input_vcf.raw_header

--- a/nextflow/vcf_prepper/main.nf
+++ b/nextflow/vcf_prepper/main.nf
@@ -21,3 +21,20 @@ WorkflowMain.initialise(workflow, params, log)
 workflow {
   VCF_PREPPER()
 }
+
+// Print summary
+workflow.onComplete {
+  println ( workflow.success ? """
+        Workflow summary
+        ----------------
+        Completed at: ${workflow.complete}
+        Duration    : ${workflow.duration}
+        Success     : ${workflow.success}
+        workDir     : ${workflow.workDir}
+        exit status : ${workflow.exitStatus}
+        """ : """
+        Failed: ${workflow.errorReport}
+        exit status : ${workflow.exitStatus}
+        """
+  )
+}

--- a/nextflow/vcf_prepper/modules/local/bed_to_bigbed.nf
+++ b/nextflow/vcf_prepper/modules/local/bed_to_bigbed.nf
@@ -18,7 +18,7 @@
  
 
 process BED_TO_BIGBED {
-  label 'process_long'
+  label 'process_high'
   
   input: 
   tuple val(meta), path(bed)

--- a/nextflow/vcf_prepper/modules/local/bed_to_bigbed.nf
+++ b/nextflow/vcf_prepper/modules/local/bed_to_bigbed.nf
@@ -18,11 +18,15 @@
  
 
 process BED_TO_BIGBED {
+  label 'process_long'
+  
   input: 
   tuple val(meta), path(bed)
   
   output:
   path "variant-${source}-details.bb"
+
+  memory 1.G
   
   shell:
   source = meta.source.toLowerCase()

--- a/nextflow/vcf_prepper/modules/local/bed_to_bigbed.nf
+++ b/nextflow/vcf_prepper/modules/local/bed_to_bigbed.nf
@@ -25,8 +25,6 @@ process BED_TO_BIGBED {
   
   output:
   path "variant-${source}-details.bb"
-
-  memory 1.G
   
   shell:
   source = meta.source.toLowerCase()

--- a/nextflow/vcf_prepper/modules/local/bed_to_bigwig.nf
+++ b/nextflow/vcf_prepper/modules/local/bed_to_bigwig.nf
@@ -23,7 +23,7 @@ process BED_TO_BIGWIG {
   output:
   path "variant-${source}-summary.bw"
   
-  memory  { (bed.size() * 4.B + 4.GB) * task.attempt }
+  memory  { (bed.size() * 4.B + 8.GB) * task.attempt }
   time    { 48.hour * task.attempt }
   afterScript 'rm all.bed'
   

--- a/nextflow/vcf_prepper/modules/local/bed_to_bigwig.nf
+++ b/nextflow/vcf_prepper/modules/local/bed_to_bigwig.nf
@@ -17,14 +17,13 @@
  */
 
 process BED_TO_BIGWIG {
-  label 'bigmem'
-  
   input: 
   tuple val(meta), path(bed)
   
   output:
   path "variant-${source}-summary.bw"
   
+  memory { bed.size() * 4.B + 2.GB }
   afterScript 'rm all.bed'
   
   shell:

--- a/nextflow/vcf_prepper/modules/local/bed_to_bigwig.nf
+++ b/nextflow/vcf_prepper/modules/local/bed_to_bigwig.nf
@@ -17,6 +17,8 @@
  */
 
 process BED_TO_BIGWIG {
+  label 'process_long'
+  
   input: 
   tuple val(meta), path(bed)
   

--- a/nextflow/vcf_prepper/modules/local/bed_to_bigwig.nf
+++ b/nextflow/vcf_prepper/modules/local/bed_to_bigwig.nf
@@ -17,15 +17,14 @@
  */
 
 process BED_TO_BIGWIG {
-  label 'process_long'
-  
   input: 
   tuple val(meta), path(bed)
   
   output:
   path "variant-${source}-summary.bw"
   
-  memory { bed.size() * 4.B + 2.GB }
+  memory  { (bed.size() * 4.B + 4.GB) * task.attempt }
+  time    { 48.hour * task.attempt }
   afterScript 'rm all.bed'
   
   shell:

--- a/nextflow/vcf_prepper/modules/local/bed_to_wig.nf
+++ b/nextflow/vcf_prepper/modules/local/bed_to_wig.nf
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 
-process BED_TO_BIGWIG {
+process BED_TO_WIG {
   input: 
   tuple val(meta), path(bed)
   
   output:
-  path "variant-${source}-summary.bw"
+  tuple val(meta), path(output_wig)
   
   memory  { (bed.size() * 4.B + 8.GB) * task.attempt }
   time    { 48.hour * task.attempt }
@@ -30,21 +30,8 @@ process BED_TO_BIGWIG {
   shell:
   source = meta.source.toLowerCase()
   output_wig = "variant-${source}-summary.wig"
-  output_bw = "${meta.genome_tracks_outdir}/variant-${source}-summary.bw"
-  chrom_sizes = meta.chrom_sizes
   
   '''
   bed_to_wig !{bed} !{output_wig}
-    
-  wigToBigWig -clip -keepAllChromosomes -fixedSummaries \
-    !{output_wig} \
-    !{chrom_sizes} \
-    !{output_bw}
-    
-  ln -sf !{output_bw} "variant-!{source}-summary.bw"
-  
-  # temp: for one source we create symlink for focus
-  cd !{meta.genome_tracks_outdir}
-  ln -sf variant-!{source}-summary.bw variant-summary.bw
   '''
 }

--- a/nextflow/vcf_prepper/modules/local/concat_beds.nf
+++ b/nextflow/vcf_prepper/modules/local/concat_beds.nf
@@ -17,7 +17,7 @@
  */
  
 process CONCAT_BEDS {
-  label 'process_long'
+  label 'process_high'
   
   input: 
   tuple val(meta), path(bed_files)

--- a/nextflow/vcf_prepper/modules/local/concat_beds.nf
+++ b/nextflow/vcf_prepper/modules/local/concat_beds.nf
@@ -17,6 +17,8 @@
  */
  
 process CONCAT_BEDS {
+  label 'process_long'
+  
   input: 
   tuple val(meta), path(bed_files)
   

--- a/nextflow/vcf_prepper/modules/local/create_rank_file.nf
+++ b/nextflow/vcf_prepper/modules/local/create_rank_file.nf
@@ -17,6 +17,8 @@
  */
 
 process CREATE_RANK_FILE {
+  label 'process_low'
+
   input:
   val rank_file
   

--- a/nextflow/vcf_prepper/modules/local/generate_chrom_sizes.nf
+++ b/nextflow/vcf_prepper/modules/local/generate_chrom_sizes.nf
@@ -17,6 +17,7 @@
  */
  
 process GENERATE_CHROM_SIZES {
+  label 'process_low'
   cache false
   
   input:

--- a/nextflow/vcf_prepper/modules/local/generate_synonym_file.nf
+++ b/nextflow/vcf_prepper/modules/local/generate_synonym_file.nf
@@ -17,6 +17,7 @@
  */
  
 process GENERATE_SYNONYM_FILE {
+  label 'process_low'
   cache false
   
   input:

--- a/nextflow/vcf_prepper/modules/local/index_vcf.nf
+++ b/nextflow/vcf_prepper/modules/local/index_vcf.nf
@@ -28,7 +28,7 @@ process INDEX_VCF {
   shell:
   index_type = meta.index_type
   flag_index = (index_type == "tbi" ? "-t" : "-c")
-  new_vcf = "${meta.genome}-${meta.source}.vcf.gz".replace("/", "_")
+  new_vcf = "${meta.genome}-${meta.source}.vcf.gz"
   vcf_index = new_vcf + ".${index_type}"
   
   '''

--- a/nextflow/vcf_prepper/modules/local/index_vcf.nf
+++ b/nextflow/vcf_prepper/modules/local/index_vcf.nf
@@ -28,7 +28,7 @@ process INDEX_VCF {
   shell:
   index_type = meta.index_type
   flag_index = (index_type == "tbi" ? "-t" : "-c")
-  new_vcf = "${meta.genome}-${meta.source}.vcf.gz"
+  new_vcf = "${meta.genome}-${meta.source}.vcf.gz".replace("/", "_")
   vcf_index = new_vcf + ".${index_type}"
   
   '''

--- a/nextflow/vcf_prepper/modules/local/process_fasta.nf
+++ b/nextflow/vcf_prepper/modules/local/process_fasta.nf
@@ -17,6 +17,7 @@
  */
  
 process PROCESS_FASTA {
+  label 'process_medium'
   cache false
   
   input:

--- a/nextflow/vcf_prepper/modules/local/remove_variants.nf
+++ b/nextflow/vcf_prepper/modules/local/remove_variants.nf
@@ -17,13 +17,13 @@
  */
  
 process REMOVE_VARIANTS {
-  label 'bigmem'
-  
   input:
   tuple val(meta), path(vcf)
   
   output:
   tuple val(meta), path(output_file)
+
+  memory { vcf.size() * 12.B + 2.GB }
   
   shell:
   output_file =  "REMOVED_" + file(vcf).getName()

--- a/nextflow/vcf_prepper/modules/local/remove_variants.nf
+++ b/nextflow/vcf_prepper/modules/local/remove_variants.nf
@@ -23,7 +23,7 @@ process REMOVE_VARIANTS {
   output:
   tuple val(meta), path(output_file)
 
-  memory { vcf.size() * 12.B + 2.GB }
+  memory { (vcf.size() * 12.B + 2.GB) * task.attempt }
   
   shell:
   output_file =  "REMOVED_" + file(vcf).getName()

--- a/nextflow/vcf_prepper/modules/local/remove_variants.nf
+++ b/nextflow/vcf_prepper/modules/local/remove_variants.nf
@@ -23,7 +23,7 @@ process REMOVE_VARIANTS {
   output:
   tuple val(meta), path(output_file)
 
-  memory { (vcf.size() * 12.B + 2.GB) * task.attempt }
+  memory { (vcf.size() * 16.B + 2.GB) * task.attempt }
   
   shell:
   output_file =  "REMOVED_" + file(vcf).getName()

--- a/nextflow/vcf_prepper/modules/local/split_vcf_chr.nf
+++ b/nextflow/vcf_prepper/modules/local/split_vcf_chr.nf
@@ -25,7 +25,7 @@ process SPLIT_VCF_CHR {
   output:
   tuple val(meta), path("split.*.vcf.gz")
 
-  memory 32.GB
+  memory { 32.GB * task.attempt }
 
   shell:
   

--- a/nextflow/vcf_prepper/modules/local/split_vcf_chr.nf
+++ b/nextflow/vcf_prepper/modules/local/split_vcf_chr.nf
@@ -25,6 +25,8 @@ process SPLIT_VCF_CHR {
   output:
   tuple val(meta), path("split.*.vcf.gz")
 
+  memory 32.GB
+
   shell:
   
   '''

--- a/nextflow/vcf_prepper/modules/local/summary_stats.nf
+++ b/nextflow/vcf_prepper/modules/local/summary_stats.nf
@@ -23,7 +23,7 @@ process SUMMARY_STATS {
   output:
   tuple val(meta), path(output_file), path(vcf_index)
 
-  memory  { (vcf.size() * 1.2.B + 2.GB) * task.attempt }
+  memory  { ((vcf.size() * 1.25 * 1.B) + 2.GB) * task.attempt }
 
   shell:
   species = meta.species

--- a/nextflow/vcf_prepper/modules/local/summary_stats.nf
+++ b/nextflow/vcf_prepper/modules/local/summary_stats.nf
@@ -16,15 +16,15 @@
  * limitations under the License.
  */
  
-process SUMMARY_STATS {
-  label 'process_medium'
-  
+process SUMMARY_STATS { 
   input: 
   tuple val(meta), path(vcf), path(vcf_index)
 
   output:
   tuple val(meta), path(output_file), path(vcf_index)
-  
+
+  memory 32.GB
+
   shell:
   species = meta.species
   assembly = meta.assembly

--- a/nextflow/vcf_prepper/modules/local/summary_stats.nf
+++ b/nextflow/vcf_prepper/modules/local/summary_stats.nf
@@ -23,7 +23,7 @@ process SUMMARY_STATS {
   output:
   tuple val(meta), path(output_file), path(vcf_index)
 
-  memory 32.GB
+  memory  { (vcf.size() * 1.2.B + 2.GB) * task.attempt }
 
   shell:
   species = meta.species

--- a/nextflow/vcf_prepper/modules/local/summary_stats.nf
+++ b/nextflow/vcf_prepper/modules/local/summary_stats.nf
@@ -29,7 +29,6 @@ process SUMMARY_STATS {
   species = meta.species
   assembly = meta.assembly
   output_file =  "UPDATED_SS_" + file(vcf).getName()
-  uncomressed_output_file = output_file.replaceFirst(/.gz$/, "")
   index_type = meta.index_type
   flag_index = (index_type == "tbi" ? "-t" : "-c")
   vcf_index = output_file + ".${index_type}"
@@ -39,9 +38,8 @@ process SUMMARY_STATS {
     !{species} \
     !{assembly} \
     !{vcf} \
-    -O !{uncomressed_output_file}
+    -O !{output_file}
   
-  bgzip !{uncomressed_output_file}
   bcftools index !{flag_index} !{output_file}
   '''
 }

--- a/nextflow/vcf_prepper/modules/local/summary_stats.nf
+++ b/nextflow/vcf_prepper/modules/local/summary_stats.nf
@@ -17,6 +17,8 @@
  */
  
 process SUMMARY_STATS {
+  label 'process_medium'
+  
   input: 
   tuple val(meta), path(vcf), path(vcf_index)
 

--- a/nextflow/vcf_prepper/modules/local/update_fields.nf
+++ b/nextflow/vcf_prepper/modules/local/update_fields.nf
@@ -17,6 +17,8 @@
  */
  
 process UPDATE_FIELDS {
+  label 'process_medium'
+
   input: 
   tuple val(meta), path(vcf), path(vcf_index)
   

--- a/nextflow/vcf_prepper/modules/local/wig_to_bigwig.nf
+++ b/nextflow/vcf_prepper/modules/local/wig_to_bigwig.nf
@@ -1,0 +1,46 @@
+#!/usr/bin/env nextflow
+
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+process WIG_TO_BIGWIG {
+  input: 
+  tuple val(meta), path(wig)
+  
+  output:
+  path "variant-${source}-summary.bw"
+  
+  memory  { (wig.size() * 6.B + 1.GB) * task.attempt }
+  time    { 48.hour * task.attempt }
+  
+  shell:
+  source = meta.source.toLowerCase()
+  output_bw = "${meta.genome_tracks_outdir}/variant-${source}-summary.bw"
+  chrom_sizes = meta.chrom_sizes
+  
+  '''
+  wigToBigWig -clip -keepAllChromosomes -fixedSummaries \
+    !{wig} \
+    !{chrom_sizes} \
+    !{output_bw}
+    
+  ln -sf !{output_bw} "variant-!{source}-summary.bw"
+  
+  # temp: for one source we create symlink for focus
+  cd !{meta.genome_tracks_outdir}
+  ln -sf variant-!{source}-summary.bw variant-summary.bw
+  '''
+}

--- a/nextflow/vcf_prepper/modules/local/wig_to_bigwig.nf
+++ b/nextflow/vcf_prepper/modules/local/wig_to_bigwig.nf
@@ -23,7 +23,7 @@ process WIG_TO_BIGWIG {
   output:
   path "variant-${source}-summary.bw"
   
-  memory  { (wig.size() * 6.B + 1.GB) * task.attempt }
+  memory  { (wig.size() * 10.B + 1.GB) * task.attempt }
   time    { 48.hour * task.attempt }
   
   shell:

--- a/nextflow/vcf_prepper/nextflow.config
+++ b/nextflow/vcf_prepper/nextflow.config
@@ -78,7 +78,7 @@ process {
   
   withName: 'runVEPonVCF'{
     cpus    = { 2 * task.attempt }
-    memory  = { 24.KB * params.bin_size * task.attempt + 1.GB }
+    memory  = { 36.KB * params.bin_size * task.attempt + 1.GB }
     time    = { 0.00008.hour * params.bin_size * task.attempt + 1.hour }
   }
 

--- a/nextflow/vcf_prepper/nextflow.config
+++ b/nextflow/vcf_prepper/nextflow.config
@@ -24,7 +24,7 @@ params {
   
   // pipeline control parameters
   bin_size = 250000
-  remove_nonunique_ids = 1
+  remove_nonunique_ids = 0
   remove_patch_regions = 1
   skip_vep = 0
   skip_tracks = 0

--- a/nextflow/vcf_prepper/nextflow.config
+++ b/nextflow/vcf_prepper/nextflow.config
@@ -78,7 +78,7 @@ process {
   
   withName: 'runVEPonVCF'{
     cpus    = { 2 * task.attempt }
-    memory  = { 36.KB * params.bin_size * task.attempt + 1.GB }
+    memory  = { 96.KB * params.bin_size * task.attempt + 1.GB }
     time    = { 0.00008.hour * params.bin_size * task.attempt + 1.hour }
   }
 

--- a/nextflow/vcf_prepper/nextflow.config
+++ b/nextflow/vcf_prepper/nextflow.config
@@ -106,3 +106,27 @@ singularity {
   enabled = true
   autoMounts = true
 }
+
+trace {
+    enabled = true
+    overwrite = true
+    file = "reports/trace.txt"
+}
+
+dag {
+    enabled = true
+    overwrite = true
+    file = "reports/flowchart.mmd"
+}
+
+timeline {
+    enabled = true
+    overwrite = true
+    file = "reports/timeline.html"
+}
+
+report {
+    enabled = true
+    overwrite = true
+    file = "reports/report.html"
+}

--- a/nextflow/vcf_prepper/nextflow.config
+++ b/nextflow/vcf_prepper/nextflow.config
@@ -78,8 +78,8 @@ process {
   
   withName: 'runVEPonVCF'{
     cpus    = { 2 * task.attempt }
-    memory  = { 16.KB * params.bin_size * task.attempt + 1.GB }
-    time    = { 48.hour * task.attempt }
+    memory  = { 24.KB * params.bin_size * task.attempt + 1.GB }
+    time    = { 0.00008.hour * params.bin_size * task.attempt + 1.hour }
   }
 
   withName: 'mergeVCF'{

--- a/nextflow/vcf_prepper/nextflow.config
+++ b/nextflow/vcf_prepper/nextflow.config
@@ -89,7 +89,7 @@ process {
 }
 
 executor {
-  queueSize = 1200
+  queueSize = 600
   submitRateLimit = '50/10sec'
 }
 

--- a/nextflow/vcf_prepper/nextflow.config
+++ b/nextflow/vcf_prepper/nextflow.config
@@ -31,53 +31,72 @@ params {
   skip_stats = 0
   force_create_config = 0
   rename_clinvar_ids = 1
+  queue_size = 1200
 }
 
 profiles {
   standard {
-    process {
-      executor = 'local'
-    }
+    executor.name = 'local'
   }
 
   lsf {
-    process{
-      executor = 'lsf'
-    
-      withLabel: bigmem {
-        queue = 'bigmem'
-        memory = '320GB'
-      }
-    }
+    executor.name = 'lsf'
   }
 
   slurm {
-    process {
-      executor = 'slurm'
-      time = '3d'
-
-      withLabel: bigmem {
-        memory = '320GB'
-      }
-    }
+    executor.name = 'slurm'
   } 
   
   // we need separate profile human because it takes lot of memory than others
-  // it is run on top of lsf profile (e.g. --profile lsf,human)
   human {
-    process {
-      memory = '32GB'
-      time = '7d'
+    process{
+      withName: 'runVEPonVCF'{
+        cpus = 2 * task.attempt
+        memory = 8.GB * task.attempt
+        time = 72.hour * task.attempt
+      }
+
+      withName: 'mergeVCF'{
+        cpus = 1 * task.attempt
+        memory = 4.GB * task.attempt
+        time = 72.hour * task.attempt
+      }
     }
   }
 }
 
 process {
   cpus = 1
-  memory = '8GB'
+  memory = 2.GB * task.attempt
+  time = 12.hour * task.attempt
   queue = 'production'
 
+  // error strategy
+  errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
+  maxRetries    = 1
+
+  withLabel: process_low {
+    memory = 1.GB * task.attempt
+    time = 1.hour * task.attempt
+  }
   
+  withLabel: process_medium {
+    cpus = 1 * task.attempt
+    memory = 4.GB * task.attempt
+    time = 24.hour * task.attempt
+  }
+  
+  withName: 'runVEPonVCF'{
+    cpus = 2 * task.attempt
+    memory = 4.GB * task.attempt
+    time = 48.hour * task.attempt
+  }
+
+  withName: 'mergeVCF'{
+    cpus = 1 * task.attempt
+    memory = 4.GB * task.attempt
+    time = 48.hour * task.attempt
+  }
 
   withLabel: bcftools {
     container = 'docker://quay.io/biocontainers/bcftools:1.13--h3a49de5_0'
@@ -89,7 +108,7 @@ process {
 }
 
 executor {
-  queueSize = 600
+  queueSize = params.queue_size
   submitRateLimit = '50/10sec'
 }
 

--- a/nextflow/vcf_prepper/nextflow.config
+++ b/nextflow/vcf_prepper/nextflow.config
@@ -47,23 +47,6 @@ profiles {
   slurm {
     executor.name = 'slurm'
   } 
-  
-  // we need separate profile human because it takes lot of memory than others
-  human {
-    process{
-      withName: 'runVEPonVCF'{
-        cpus    = { 2 * task.attempt }
-        memory  = { 8.GB * task.attempt }
-        time    = { 72.hour * task.attempt }
-      }
-
-      withName: 'mergeVCF'{
-        cpus    = { 1 * task.attempt }
-        memory  = { 4.GB * task.attempt }
-        time    = { 72.hour * task.attempt }
-      }
-    }
-  }
 }
 
 process {
@@ -87,15 +70,15 @@ process {
     time    = { 24.hour * task.attempt }
   }
 
-  withLabel: process_long {
+  withLabel: process_high {
     cpus    = { 1 * task.attempt }
-    memory  = { 4.GB * task.attempt }
+    memory  = { 8.GB * task.attempt }
     time    = { 48.hour * task.attempt }
   }
   
   withName: 'runVEPonVCF'{
     cpus    = { 2 * task.attempt }
-    memory  = { 4.GB * task.attempt }
+    memory  = { 16.KB * params.bin_size * task.attempt + 1.GB }
     time    = { 48.hour * task.attempt }
   }
 

--- a/nextflow/vcf_prepper/nextflow.config
+++ b/nextflow/vcf_prepper/nextflow.config
@@ -32,6 +32,7 @@ params {
   force_create_config = 0
   rename_clinvar_ids = 1
   queue_size = 1200
+  queue = 'production'
 }
 
 profiles {
@@ -51,51 +52,57 @@ profiles {
   human {
     process{
       withName: 'runVEPonVCF'{
-        cpus = 2 * task.attempt
-        memory = 8.GB * task.attempt
-        time = 72.hour * task.attempt
+        cpus    = { 2 * task.attempt }
+        memory  = { 8.GB * task.attempt }
+        time    = { 72.hour * task.attempt }
       }
 
       withName: 'mergeVCF'{
-        cpus = 1 * task.attempt
-        memory = 4.GB * task.attempt
-        time = 72.hour * task.attempt
+        cpus    = { 1 * task.attempt }
+        memory  = { 4.GB * task.attempt }
+        time    = { 72.hour * task.attempt }
       }
     }
   }
 }
 
 process {
-  cpus = 1
-  memory = 2.GB * task.attempt
-  time = 12.hour * task.attempt
-  queue = 'production'
+  cpus    = 1
+  memory  = { 2.GB * task.attempt }
+  time    = { 12.hour * task.attempt }
+  queue   = params.queue
 
   // error strategy
   errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
   maxRetries    = 1
 
   withLabel: process_low {
-    memory = 1.GB * task.attempt
-    time = 1.hour * task.attempt
+    memory  = { 1.GB * task.attempt }
+    time    = { 1.hour * task.attempt }
   }
   
   withLabel: process_medium {
-    cpus = 1 * task.attempt
-    memory = 4.GB * task.attempt
-    time = 24.hour * task.attempt
+    cpus    = { 1 * task.attempt }
+    memory  = { 4.GB * task.attempt }
+    time    = { 24.hour * task.attempt }
+  }
+
+  withLabel: process_long {
+    cpus    = { 1 * task.attempt }
+    memory  = { 4.GB * task.attempt }
+    time    = { 48.hour * task.attempt }
   }
   
   withName: 'runVEPonVCF'{
-    cpus = 2 * task.attempt
-    memory = 4.GB * task.attempt
-    time = 48.hour * task.attempt
+    cpus    = { 2 * task.attempt }
+    memory  = { 4.GB * task.attempt }
+    time    = { 48.hour * task.attempt }
   }
 
   withName: 'mergeVCF'{
-    cpus = 1 * task.attempt
-    memory = 4.GB * task.attempt
-    time = 48.hour * task.attempt
+    cpus    = { 1 * task.attempt }
+    memory  = { 4.GB * task.attempt }
+    time    = { 48.hour * task.attempt }
   }
 
   withLabel: bcftools {

--- a/nextflow/vcf_prepper/nextflow.config
+++ b/nextflow/vcf_prepper/nextflow.config
@@ -13,10 +13,10 @@ params {
   ini_file = "${projectDir}/assets/DEFAULT.ini"
   rank_file = "${projectDir}/assets/variation_consequnce_rank.json"
   
-  // data directories - only work for human
-  cache_dir = "/nfs/production/flicek/ensembl/variation/data/VEP/tabixconverted"
-  fasta_dir = "/nfs/production/flicek/ensembl/variation/data/VEP/fasta"
-  conservation_data_dir = "/nfs/production/flicek/ensembl/variation/data/Conservation"
+  // data directories
+  cache_dir = null
+  fasta_dir = null
+  conservation_data_dir = null
   
   // output dir
   output_dir = "/nfs/production/flicek/ensembl/variation/new_website"

--- a/nextflow/vcf_prepper/subworkflows/local/prepare_genome.nf
+++ b/nextflow/vcf_prepper/subworkflows/local/prepare_genome.nf
@@ -46,9 +46,9 @@ workflow PREPARE_GENOME {
         genome_tracks_outdir = "${params.output_dir}/tracks/${meta.genome_uuid}"
         file(genome_tracks_outdir).mkdirs()
         
-        cache_dir = meta.species ==~ "homo_sapiens.*" ? params.cache_dir : genome_temp_dir
-        fasta_dir = meta.species ==~ "homo_sapiens.*" ? params.fasta_dir : genome_temp_dir
-        conservation_data_dir = meta.species ==~ "homo_sapiens.*" ? params.conservation_data_dir : genome_temp_dir
+        cache_dir = params.cache_dir ? params.cache_dir : genome_temp_dir
+        fasta_dir = params.fasta_dir ? params.fasta_dir : genome_temp_dir
+        conservation_data_dir = params.conservation_data_dir ? params.conservation_data_dir : genome_temp_dir
         
         [ meta + [
             synonym_file: synonym_file,

--- a/nextflow/vcf_prepper/subworkflows/local/run_vep.nf
+++ b/nextflow/vcf_prepper/subworkflows/local/run_vep.nf
@@ -56,7 +56,8 @@ workflow RUN_VEP {
   .map {
     meta, vcf ->
       // tag here is the output vcf file from nextflow-vep
-      tag = "${meta.genome_temp_dir}/${meta.genome}-${meta.source}_VEP.vcf.gz"
+      filename = file("${meta.genome}-${meta.source}").getSimpleName() + "_VEP.vcf.gz"
+      tag = "${meta.genome_temp_dir}/${filename}"
 
       [tag, meta]
   }
@@ -65,6 +66,10 @@ workflow RUN_VEP {
     tag, meta ->
       vcf = tag
       vcf_index = "${tag}.${meta.index_type}"
+
+      if (! file(vcf).exists() || ! file(vcf_index).exists()){
+        exit 1, "ERROR: Could not find nextflow-vep output files. Check the following - \n\tVCF - ${vcf}\n\tVCF index - ${vcf_index}"
+      }
       
       [meta, vcf, vcf_index]
   }.set { ch_post_vep }

--- a/nextflow/vcf_prepper/subworkflows/local/run_vep.nf
+++ b/nextflow/vcf_prepper/subworkflows/local/run_vep.nf
@@ -56,8 +56,7 @@ workflow RUN_VEP {
   .map {
     meta, vcf ->
       // tag here is the output vcf file from nextflow-vep
-      filename = "${meta.genome}-${meta.source}_VEP.vcf.gz".replace("/", "_")
-      tag = "${meta.genome_temp_dir}/${filename}"
+      tag = "${meta.genome_temp_dir}/${meta.genome}-${meta.source}_VEP.vcf.gz"
 
       [tag, meta]
   }

--- a/nextflow/vcf_prepper/subworkflows/local/run_vep.nf
+++ b/nextflow/vcf_prepper/subworkflows/local/run_vep.nf
@@ -56,7 +56,9 @@ workflow RUN_VEP {
   .map {
     meta, vcf ->
       // tag here is the output vcf file from nextflow-vep
-      tag = "${meta.genome_temp_dir}/${meta.genome}-${meta.source}_VEP.vcf.gz"    
+      filename = "${meta.genome}-${meta.source}_VEP.vcf.gz".replace("/", "_")
+      tag = "${meta.genome_temp_dir}/${filename}"
+
       [tag, meta]
   }
   .join ( vep.out, failOnDuplicate: true )

--- a/nextflow/vcf_prepper/subworkflows/local/run_vep.nf
+++ b/nextflow/vcf_prepper/subworkflows/local/run_vep.nf
@@ -47,7 +47,7 @@ workflow RUN_VEP {
       vep_meta.index_type = meta.index_type
       vep_meta.filters = "amino_acids not match X[A-Za-z*]?\\/"
 
-      [vep_meta, vcf, vcf_index, meta.vep_config]
+      [meta: vep_meta, file: vcf, index: vcf_index, vep_config: meta.vep_config]
   }
   .set { ch_vep }
   vep( ch_vep )

--- a/nextflow/vcf_prepper/workflows/vcf_prepper.nf
+++ b/nextflow/vcf_prepper/workflows/vcf_prepper.nf
@@ -35,7 +35,8 @@ include { SPLIT_VCF } from "../subworkflows/local/split_vcf.nf"
 include { VCF_TO_BED } from "../modules/local/vcf_to_bed.nf"
 include { CONCAT_BEDS } from "../modules/local/concat_beds.nf"
 include { BED_TO_BIGBED } from "../modules/local/bed_to_bigbed.nf"
-include { BED_TO_BIGWIG } from "../modules/local/bed_to_bigwig.nf"
+include { BED_TO_WIG } from "../modules/local/bed_to_wig.nf"
+include { WIG_TO_BIGWIG } from "../modules/local/wig_to_bigwig.nf"
 include { SUMMARY_STATS } from "../modules/local/summary_stats.nf"
 
 def parse_config (config) {
@@ -120,7 +121,8 @@ workflow VCF_PREPPER {
     // create source tracks
     // TODO: remove symlink creation for focus track when we have multiple source
     BED_TO_BIGBED( CONCAT_BEDS.out )
-    BED_TO_BIGWIG( CONCAT_BEDS.out )
+    BED_TO_WIG( CONCAT_BEDS.out )
+    WIG_TO_BIGWIG( BED_TO_WIG.out )
 
     // if track generation is run vep-ed VCF file move needs to wait for this step to finish
     SPLIT_VCF.out

--- a/nextflow/vcf_prepper/workflows/vcf_prepper.nf
+++ b/nextflow/vcf_prepper/workflows/vcf_prepper.nf
@@ -53,6 +53,9 @@ def parse_config (config) {
       meta.assembly = source_data.assembly
       meta.source = source_data.source_name.replace(" ", "_")
       meta.file_type = source_data.file_type
+
+      meta.source = meta.source.replace(" ", "%20")
+      meta.source = meta.source.replace("/", "%2F")
       
       input_set.add([meta, vcf])
     }  

--- a/scripts/create_track_api_metadata.py
+++ b/scripts/create_track_api_metadata.py
@@ -91,6 +91,9 @@ def main(args = None):
         source = species_metadata[genome_uuid]["source_name"]
         species = species_metadata[genome_uuid]["species"]
 
+        source.replace("%20", " ")
+        source.replace("%2F", "/")
+
         source_info = get_source_info(source)
         source_url = get_source_url(source)
 


### PR DESCRIPTION
Related to [ENSVAR-6218](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6218)

TBD: separate force flag for config files and annotation files?

- Updates to VEP config ini file 
  - Added following plugins -
    - REVEL
    - ClinPred
    - Downstream
    - Add pCADD
  - Allow some plugin files to be absent (just skip) , e.g - MaveDB and AlphaMissense do not have file for GRCh37 assembly.
  - Update gnomAD v4.1 file locations and add gnomAD frequency for all HPRC assemblies
  - Added **mouse MGP** frequency.
- Resource optimisation -
  - Memory -  
    - Added low, medium, and high type resource. And removed separate human profile.
    - Added `RunVEP` memory that depends on bin size.
    - Separate `wigToBigWig` process as it takes more memory and added memory based on wig file size.
    - Added `remove_variants` and `summary_stats` memory based in vcf file size.
    - Added `split_vcf` memory as fixed `32GB` (probably can be more refined later)
  - Storage - 
    - Summary stats was taking a lot of storage as it work on uncompress file. Made it so that it can work on compress file and take less storage.   
- Accustom nextflow-vep changes -
  - Update run_vep sub_workflow arguments, related to change in this PR - https://github.com/Ensembl/ensembl-vep/pull/1675
  - Update the expected output filename from nextflow-vep (used as `tag` in run_vep sub_workflow), related to change in this PR - https://github.com/Ensembl/ensembl-vep/pull/1675/files#diff-b40e82cf98d3bf8cb166f5ef961695009b72591d9800fa738d8aad7752db5914R35
- Allow force creation of cache and FASTA for human too. Updated to download FASTA and cache for human 37 assembly. 
- Bugfix: skip plugin if file does not exist. Adding `skip` option to `check_plugin_files` function was adding plugin even if file not present instead of skipping. Fixed that bug. This bug was causing several folds slowness due to Conservation plugin with wrong file.
- Bugfix: pipeline failed if source had `/` in its name. Replacing it with ASCII value.
- Print pipeline summaries and generate reports by default.