### PR TITLE
Add script to automate VCF prepper input config creation

### DIFF
--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -116,7 +116,7 @@ def parse_ini(ini_file: str, section: str = "database") -> dict:
     return {"host": host, "port": port, "user": user}
 
 
-def get_ensembl_species(server: dict, meta_db: str) -> str:
+def get_ensembl_species(server: dict, meta_db: str) -> dict:
 
     """
     Query the metadata database for all Ensembl species and their assemblies.

--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -73,7 +73,16 @@ def parse_args(args=None):
         required=False,
         help="Config file with database server information",
     )
-    
+    parser.add_argument(
+        "-O",
+        "--output_file",
+        dest="output_file",
+        type=str,
+        default="input_config.json",
+        required=False,
+        help="Full path to output file",
+    )
+
     return parser.parse_args(args)
 
 

--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -690,7 +690,7 @@ def main(args=None):
     # Prepare empty dicts
     ensembl_prepared = {}
     ensembl_planned = {}
-    eva_updates = {}
+    ensembl_released = {}
 
     # Loop over only those assemblies present in BOTH Ensembl and EVA
     for asm in set(ensembl_assemblies) & set(eva_species):
@@ -762,7 +762,7 @@ def main(args=None):
 
                 if update and seq_region_matches(eva_file=file_loc, ensembl_file=vcf_path):
                     genome_key = f"{meta['species']}_{meta['assembly_name']}"
-                    eva_updates.setdefault(genome_key, []).append(record)
+                    ensembl_released.setdefault(genome_key, []).append(record)
 
     # Write the output JSON files
     with open(
@@ -776,8 +776,8 @@ def main(args=None):
     ) as out:
         json.dump(ensembl_planned, out, indent=4)
 
-    with open(os.path.join(args.output_dir, "eva_updates.json"), "w") as out:
-        json.dump(eva_updates, out, indent=4)
+    with open(os.path.join(args.output_dir, "ensembl_released.json"), "w") as out:
+        json.dump(ensembl_released, out, indent=4)
 
 
 if __name__ == "__main__":

--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -54,16 +54,16 @@ EVA_REST_ENDPOINT = "https://www.ebi.ac.uk/eva/webservices/release"
 
 def parse_args(args=None):
     """
-        Parse all command-line arguments for the script.
+    Parse all command-line arguments for the script.
 
-        Raises:
-            SystemExit: Raised internally by *argparse* if `-h/--help`
-                is requested or if invalid arguments are supplied.
+    Raises:
+        SystemExit: Raised internally by *argparse* if `-h/--help`
+            is requested or if invalid arguments are supplied.
 
-        Returns:
-            argparse.Namespace:  Namespace whose attributes are  
-                `ini_file`, `output_dir`, and `tmp_dir`, already
-                populated with defaults or user-supplied values.
+    Returns:
+        argparse.Namespace:  Namespace whose attributes are
+            `ini_file`, `output_dir`, and `tmp_dir`, already
+            populated with defaults or user-supplied values.
     """
 
     parser = argparse.ArgumentParser(
@@ -102,15 +102,15 @@ def parse_args(args=None):
 
 def parse_ini(ini_file: str, section: str = "database") -> dict:
     """
-        Load connection parameters from an INI file.
+    Load connection parameters from an INI file.
 
-        Raises:
-            SystemExit: If the requested *section* is absent from
-                the file (an error message is printed before exit).
+    Raises:
+        SystemExit: If the requested *section* is absent from
+            the file (an error message is printed before exit).
 
-        Returns:
-            dict:  Keys `host`, `port`, `user` – suitable for passing
-                straight to the MySQL command-line client.
+    Returns:
+        dict:  Keys `host`, `port`, `user` – suitable for passing
+            straight to the MySQL command-line client.
     """
 
     config = configparser.ConfigParser()
@@ -129,13 +129,13 @@ def parse_ini(ini_file: str, section: str = "database") -> dict:
 
 def get_ensembl_species(server: dict, meta_db: str) -> dict:
     """
-        Query metadata db for every available genome.
+    Query metadata db for every available genome.
 
-        Raises:
-            SystemExit: If the underlying `mysql` subprocess fails.
+    Raises:
+        SystemExit: If the underlying `mysql` subprocess fails.
 
-        Returns:
-            dict:  `{genome_uuid: {species, assembly_id, assembly_name}}`.
+    Returns:
+        dict:  `{genome_uuid: {species, assembly_id, assembly_name}}`.
     """
 
     query = f"""
@@ -187,14 +187,14 @@ def get_ensembl_species(server: dict, meta_db: str) -> dict:
 
 def get_ensembl_vcf_filepaths(server: dict, meta_db: str) -> dict:
     """
-        Retrieve the location of VCFs already produced by the
-        VCF-prepper pipeline.
+    Retrieve the location of VCFs already produced by the
+    VCF-prepper pipeline.
 
-        Raises:
-            SystemExit: On failure of the SQL query / subprocess.
+    Raises:
+        SystemExit: On failure of the SQL query / subprocess.
 
-        Returns:
-            dict:  `{genome_uuid: {species, assembly_id, file_path}}`.
+    Returns:
+        dict:  `{genome_uuid: {species, assembly_id, file_path}}`.
     """
 
     query = f"""
@@ -246,7 +246,9 @@ def get_ensembl_vcf_filepaths(server: dict, meta_db: str) -> dict:
     ensembl_filepaths = {}
     for filepath_meta in process.stdout.decode().strip().split("\n"):
         (accession, production_name, genome_uuid, file_path) = filepath_meta.split()
-        ensembl_filepaths[genome_uuid] = { # using genome_uuid as key, as assembly_id isn't unique i.e. GCA_015227675.2 is mapped to two genome_uuid
+        ensembl_filepaths[
+            genome_uuid
+        ] = {  # using genome_uuid as key, as assembly_id isn't unique i.e. GCA_015227675.2 is mapped to two genome_uuid
             "species": production_name,
             "assembly_id": accession,
             "file_path": file_path,
@@ -257,15 +259,15 @@ def get_ensembl_vcf_filepaths(server: dict, meta_db: str) -> dict:
 
 def get_ensembl_variant_counts(server: dict, meta_db: str) -> dict:
     """
-        Pull the pre-computed “short-variant” counts from the
-        metadata db.
+    Pull the pre-computed “short-variant” counts from the
+    metadata db.
 
-        Raises:
-            SystemExit: When the MySQL subprocess exits non-zero.
+    Raises:
+        SystemExit: When the MySQL subprocess exits non-zero.
 
-        Returns:
-            dict:  `{genome_uuid: {"assembly": accession,
-                                "variant_count": int}}`.
+    Returns:
+        dict:  `{genome_uuid: {"assembly": accession,
+                            "variant_count": int}}`.
     """
 
     query = f"""
@@ -315,7 +317,7 @@ def get_ensembl_variant_counts(server: dict, meta_db: str) -> dict:
         (assembly, genome_uuid, variant_count) = ensembl_variant_count.split()
         ensembl_variant_counts[genome_uuid] = {
             "assembly": assembly,
-            "variant_count": int(variant_count)
+            "variant_count": int(variant_count),
         }
 
     return ensembl_variant_counts
@@ -323,18 +325,18 @@ def get_ensembl_variant_counts(server: dict, meta_db: str) -> dict:
 
 def get_eva_version_from_ensembl_vcf(vcf_path: str):
     """
-        Scan the header of the Ensembl VCF and extract
-        the EVA release version recorded in the `##source=` line.
+    Scan the header of the Ensembl VCF and extract
+    the EVA release version recorded in the `##source=` line.
 
-        Raises:
-            FileNotFoundError: If vcf_path does not exist.
-            ValueError:        If the `version="…"` token is present
-                but cannot be coerced to an `int`.
+    Raises:
+        FileNotFoundError: If vcf_path does not exist.
+        ValueError:        If the `version="…"` token is present
+            but cannot be coerced to an `int`.
 
-        Returns:
-            int | None:  The EVA release number, or None when the
-                header lacks an EVA `##source` line or version 
-                isn't an `int`.
+    Returns:
+        int | None:  The EVA release number, or None when the
+            header lacks an EVA `##source` line or version
+            isn't an `int`.
     """
 
     path = Path(vcf_path)
@@ -363,14 +365,14 @@ def get_eva_version_from_ensembl_vcf(vcf_path: str):
 
 def get_latest_eva_version() -> int:
     """
-        Query the EVA REST API for the most recent public release version.
+    Query the EVA REST API for the most recent public release version.
 
-        Raises:
-            SystemExit: If the HTTP request fails or an unexpected
-                JSON payload is returned.
+    Raises:
+        SystemExit: If the HTTP request fails or an unexpected
+            JSON payload is returned.
 
-        Returns:
-            int:  The latest EVA release version.
+    Returns:
+        int:  The latest EVA release version.
     """
 
     url = EVA_REST_ENDPOINT + "/v1/info/latest"
@@ -396,15 +398,15 @@ def get_latest_eva_version() -> int:
 
 def get_eva_species(release_version: int) -> dict:
     """
-        Fetch per-species statistics for the requested EVA release
-        and retain only assemblies with ≥ 5000 RS IDs.
+    Fetch per-species statistics for the requested EVA release
+    and retain only assemblies with ≥ 5000 RS IDs.
 
-        Raises:
-            SystemExit: On HTTP / JSON errors.
+    Raises:
+        SystemExit: On HTTP / JSON errors.
 
-        Returns:
-            dict:  `{assembly_accession: {species, accession,
-                    release_folder, taxonomy_id, variant_count}}`.
+    Returns:
+        dict:  `{assembly_accession: {species, accession,
+                release_folder, taxonomy_id, variant_count}}`.
     """
 
     eva_species = {}
@@ -467,15 +469,15 @@ def _tabix_list(path: str, workdir: Path = Path.cwd()) -> Optional[List[str]]:
 
 def _header_contigs(path: str) -> List[str]:
     """
-        Parse `##contig=<ID=…>` header lines from a VCF
-        (compressed or plain).
+    Parse `##contig=<ID=…>` header lines from a VCF
+    (compressed or plain).
 
-        Raises:
-            IOError:  If the file cannot be read.
+    Raises:
+        IOError:  If the file cannot be read.
 
-        Returns:
-            list[str]:  All contig IDs found - in the order they
-                appear in the header.
+    Returns:
+        list[str]:  All contig IDs found - in the order they
+            appear in the header.
     """
 
     opener = gzip.open if path.endswith(".gz") else open
@@ -489,22 +491,22 @@ def _header_contigs(path: str) -> List[str]:
 
 def seq_region_matches(eva_file: str, ensembl_file: str, tmp_dir: Path) -> bool:
     """
-        Determine whether a remote EVA VCF and a local Ensembl VCF
-        reference at least one common sequence region.
+    Determine whether a remote EVA VCF and a local Ensembl VCF
+    reference at least one common sequence region.
 
-        The function attempts `tabix -l` on both files, builds a
-        temporary index for the local VCF when necessary, and finally
-        falls back to a header parse if indexing fails.
+    The function attempts `tabix -l` on both files, builds a
+    temporary index for the local VCF when necessary, and finally
+    falls back to a header parse if indexing fails.
 
-        Raises:
-            ValueError:  When *tmp_dir* does not exist.
-            Subprocess errors that are thrown while
-                copying or indexing files.
+    Raises:
+        ValueError:  When *tmp_dir* does not exist.
+        Subprocess errors that are thrown while
+            copying or indexing files.
 
-        Returns:
-            bool:  *True* if a shared contig is found, *False* otherwise.
+    Returns:
+        bool:  *True* if a shared contig is found, *False* otherwise.
     """
-    
+
     # Set up temp_dir/work to hold tmp files
     if not tmp_dir.is_dir():
         raise ValueError(f"--tmp_dir must exist: {tmp_dir}")
@@ -561,7 +563,9 @@ def seq_region_matches(eva_file: str, ensembl_file: str, tmp_dir: Path) -> bool:
                     f"{build.stderr.strip()}\n"
                 )
                 try:
-                    sys.stderr.write(f"[INFO] Fall-back: attempting header-parse to retrieve contigs\n")
+                    sys.stderr.write(
+                        f"[INFO] Fall-back: attempting header-parse to retrieve contigs\n"
+                    )
                     ens_seq = _header_contigs(tmp_copy)
                     sys.stderr.write(
                         f"[INFO] Contigs parsed from header successfully"
@@ -583,15 +587,15 @@ def seq_region_matches(eva_file: str, ensembl_file: str, tmp_dir: Path) -> bool:
 
 def get_ensembl_release_status(server: dict, meta_db: str) -> str:
     """
-        Collect “planned” or “prepared” release statuses recorded in
-        metadata for every genome.
+    Collect “planned” or “prepared” release statuses recorded in
+    metadata for every genome.
 
-        Raises:
-            SystemExit: If the MySQL query fails.
+    Raises:
+        SystemExit: If the MySQL query fails.
 
-        Returns:
-            dict:  `{genome_uuid: {species, release_status,
-                                release_id, assembly_id}}`
+    Returns:
+        dict:  `{genome_uuid: {species, release_status,
+                            release_id, assembly_id}}`
     """
 
     query = f"""
@@ -635,35 +639,37 @@ def get_ensembl_release_status(server: dict, meta_db: str) -> str:
 
     ensembl_release_status = defaultdict(list)
     for release_meta in process.stdout.decode().strip().split("\n"):
-        (genome_uuid, production_name, assembly_id, status, release_id) = release_meta.split()
+        (genome_uuid, production_name, assembly_id, status, release_id) = (
+            release_meta.split()
+        )
         ensembl_release_status[genome_uuid] = {
-                "species": re.sub(
-                    r"_gca.*$", "", production_name
-                ),  # remove accession suffix
-                "release_status": status,
-                "release_id": release_id,
-                "assembly_id": assembly_id
-            }
+            "species": re.sub(
+                r"_gca.*$", "", production_name
+            ),  # remove accession suffix
+            "release_status": status,
+            "release_id": release_id,
+            "assembly_id": assembly_id,
+        }
 
     return ensembl_release_status
 
 
 def main(args=None):
     """
-        Run the auto-discovery workflow:
+    Run the auto-discovery workflow:
 
-        1.  Load CLI arguments and check paths.
-        2.  Fetch EVA and Ensembl metadata (species, VCFs, counts, statuses).
-        3.  Decide which genomes need to be processed.
-        4.  Emit three JSON configuration files.
+    1.  Load CLI arguments and check paths.
+    2.  Fetch EVA and Ensembl metadata (species, VCFs, counts, statuses).
+    3.  Decide which genomes need to be processed.
+    4.  Emit three JSON configuration files.
 
-        Raises:
-            SystemExit:  For argument/ environment problems.
-            ValueError:  From helpers (e.g. `seq_region_matches`)
-                when conditions are not met.
+    Raises:
+        SystemExit:  For argument/ environment problems.
+        ValueError:  From helpers (e.g. `seq_region_matches`)
+            when conditions are not met.
 
-        Returns:
-            None
+    Returns:
+        None
     """
 
     args = parse_args(args)
@@ -683,9 +689,7 @@ def main(args=None):
 
     # Pull Ensembl metadata
     server = parse_ini(args.ini_file, "metadata")
-    ensembl_species = get_ensembl_species(
-        server, meta_db="ensembl_genome_metadata"
-    )
+    ensembl_species = get_ensembl_species(server, meta_db="ensembl_genome_metadata")
     ensembl_vcf_paths = get_ensembl_vcf_filepaths(
         server, meta_db="ensembl_genome_metadata"
     )
@@ -696,7 +700,7 @@ def main(args=None):
         server, meta_db="ensembl_genome_metadata"
     )
 
-    # Get unique assemblies present in Ensembl 
+    # Get unique assemblies present in Ensembl
     ensembl_assemblies = [x.get("assembly_id") for x in ensembl_vcf_paths.values()]
     print(f"[INFO] {len(set(ensembl_assemblies))} unique Ensembl assemblies identified")
 
@@ -726,23 +730,21 @@ def main(args=None):
 
     # Loop over only those assemblies present in BOTH Ensembl and EVA
     for asm in set(ensembl_assemblies) & set(eva_species):
-
         # Get Ensembl genome_uuids associated with assemblies present in BOTH Ensembl and EVA
         associated_uuids = [
-            uuid
-            for uuid, rec in ensembl_species.items()
-            if rec["assembly_id"] == asm
+            uuid for uuid, rec in ensembl_species.items() if rec["assembly_id"] == asm
         ]
-        
+
         for uuid in associated_uuids:
-            
             # Grab Ensembl metadata for assembly-uuid
             meta = ensembl_species[uuid]
             status = ensembl_status.get(uuid)
             vcf_meta = ensembl_vcf_paths.get(uuid)
 
             sp = meta["species"]
-            print(f"[INFO] Processing... Assembly ID: {asm}. Species: {sp}. Genome: {uuid}.")
+            print(
+                f"[INFO] Processing... Assembly ID: {asm}. Species: {sp}. Genome: {uuid}."
+            )
 
             # Grab EVA metadata for assembly
             eva_meta = eva_species[asm]
@@ -765,7 +767,7 @@ def main(args=None):
                 "assembly": meta["assembly_name"],
                 "source_name": "EVA",
                 "file_type": "remote",
-                "file_location": file_loc, # EVA file URL
+                "file_location": file_loc,  # EVA file URL
             }
 
             # Check for genebuild/assembly candidates - candidates must have a planned, prepared or both statuses in the metdata db
@@ -781,35 +783,49 @@ def main(args=None):
 
             # Check for EVA variant update candidates - only if we already have a VCF, and only if we haven't included it already (as a genebuild/assembly candidate)
             elif vcf_meta:
-                print(f"[INFO] Not genebuild candidate in the metadata db, so checking EVA")
+                print(
+                    f"[INFO] Not genebuild candidate in the metadata db, so checking EVA"
+                )
                 vcf_path = vcf_meta["file_path"]
 
                 # If the current Ensembl EVA version can be grabbed from vcf header, grab and compare, otherwise revert to variant count comparison
-                eva_ensembl_version = get_eva_version_from_ensembl_vcf(vcf_path=vcf_path)
+                eva_ensembl_version = get_eva_version_from_ensembl_vcf(
+                    vcf_path=vcf_path
+                )
 
                 update = False
                 if eva_ensembl_version:
-                    print(f"[INFO] EVA version parsed from Ensembl file header: {eva_ensembl_version}")
+                    print(
+                        f"[INFO] EVA version parsed from Ensembl file header: {eva_ensembl_version}"
+                    )
                     if eva_ensembl_version < eva_release:
                         update = True
                 else:
-                    print(f"[INFO] EVA version not found in Ensembl file header, comparing variant counts as fall-back")
-                    ensembl_variant_count = ensembl_variant_counts.get(uuid)["variant_count"]
+                    print(
+                        f"[INFO] EVA version not found in Ensembl file header, comparing variant counts as fall-back"
+                    )
+                    ensembl_variant_count = ensembl_variant_counts.get(uuid)[
+                        "variant_count"
+                    ]
                     if ensembl_variant_count < eva_meta["variant_count"]:
-                        update = True    
+                        update = True
 
-                if update and seq_region_matches(eva_file=file_loc, ensembl_file=vcf_path, tmp_dir=Path(args.tmp_dir)):
+                if update and seq_region_matches(
+                    eva_file=file_loc, ensembl_file=vcf_path, tmp_dir=Path(args.tmp_dir)
+                ):
                     genome_key = f"{meta['species']}_{meta['assembly_name']}"
                     ensembl_released.setdefault(genome_key, []).append(record)
 
     # Write the output JSON files
     print(f"[INFO] Auto-discovery complete. Writing JSON files.")
 
-    prepared_json  = os.path.join(args.output_dir,
-                                f"ensembl_prepared_{prepared_release_id}.json")
-    planned_json   = os.path.join(args.output_dir,
-                                f"ensembl_planned_{planned_release_id}.json")
-    released_json  = os.path.join(args.output_dir, "ensembl_released.json")
+    prepared_json = os.path.join(
+        args.output_dir, f"ensembl_prepared_{prepared_release_id}.json"
+    )
+    planned_json = os.path.join(
+        args.output_dir, f"ensembl_planned_{planned_release_id}.json"
+    )
+    released_json = os.path.join(args.output_dir, "ensembl_released.json")
 
     with open(prepared_json, "w") as fh:
         json.dump(ensembl_prepared, fh, indent=4)

--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -74,13 +74,13 @@ def parse_args(args=None):
         help="Config file with database server information",
     )
     parser.add_argument(
-        "-O",
-        "--output_file",
-        dest="output_file",
+        "-O", 
+        "--output_dir",
+        dest="output_dir",
         type=str,
-        default="input_config.json",
+        default=".",
         required=False,
-        help="Full path to output file",
+        help="Dir in which to write output files",
     )
 
     return parser.parse_args(args)
@@ -543,6 +543,7 @@ def main(args=None):
     """
 
     args = parse_args(args)
+    os.makedirs(args.output_dir, exist_ok=True)
 
     # Pull EVA metadata
     eva_release       = get_latest_eva_version()
@@ -631,14 +632,14 @@ def main(args=None):
                 eva_updates.setdefault(genome_key, []).append(record)
 
     # Write the output JSON files 
-    with open(f"ensembl_prepared_{prepared_release_id}.json", "w") as out:
+    with open(os.path.join(args.output_dir, f"ensembl_prepared_{prepared_release_id}.json"), "w") as out:
         json.dump(ensembl_prepared, out, indent=4)
 
-    with open(f"ensembl_planned_{planned_release_id}.json", "w") as out:
+    with open(os.path.join(args.output_dir, f"ensembl_planned_{planned_release_id}.json"), "w") as out:
         json.dump(ensembl_planned, out, indent=4)
 
-    with open(f"eva_updates.json", "w") as out:
-        json.dump(eva_updates, out, indent=4)
+    with open(eva_path, "w") as out:
+        json.dump(os.path.join(args.output_dir, "eva_updates.json"), out, indent=4)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -265,7 +265,6 @@ def count_ensembl_variants(ensembl_vcf_path: str) -> int:
     """
 
     try:
-        # Run the zgrep command with subprocess.check_output to capture output
         output = subprocess.check_output(
             ["zgrep", "-vc", "^#", ensembl_vcf_path], stderr=subprocess.STDOUT
         )
@@ -522,7 +521,6 @@ def get_ensembl_release_status(server: dict, meta_db: str) -> str:
         (production_name, accession, status, release_id) = release_meta.split()
         ensembl_release_status[accession] = {
             "species": re.sub(r'_gca.*$', '', production_name), # remove accession suffix
-            # "species": production_name,
             "release_status": status,
             "release_id": release_id,
         }

--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -636,8 +636,8 @@ def main(args=None):
     with open(os.path.join(args.output_dir, f"ensembl_planned_{planned_release_id}.json"), "w") as out:
         json.dump(ensembl_planned, out, indent=4)
 
-    with open(eva_path, "w") as out:
-        json.dump(os.path.join(args.output_dir, "eva_updates.json"), out, indent=4)
+    with open(os.path.join(args.output_dir, "eva_updates.json"), "w") as out:
+        json.dump(eva_updates, out, indent=4)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -73,16 +73,7 @@ def parse_args(args=None):
         required=False,
         help="Config file with database server information",
     )
-    parser.add_argument(
-        "-O",
-        "--output_file",
-        dest="output_file",
-        type=str,
-        default="input_config.json",
-        required=False,
-        help="Full path to output file",
-    )
-
+    
     return parser.parse_args(args)
 
 

--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -50,7 +50,6 @@ EVA_REST_ENDPOINT = "https://www.ebi.ac.uk/eva/webservices/release"
 
 
 def parse_args(args=None):
-
     """
     Parse command-line arguments.
 
@@ -75,7 +74,7 @@ def parse_args(args=None):
         help="Config file with database server information",
     )
     parser.add_argument(
-        "-O", 
+        "-O",
         "--output_dir",
         dest="output_dir",
         type=str,
@@ -88,7 +87,6 @@ def parse_args(args=None):
 
 
 def parse_ini(ini_file: str, section: str = "database") -> dict:
-
     """
     Read database connection details from an INI file.
 
@@ -118,7 +116,6 @@ def parse_ini(ini_file: str, section: str = "database") -> dict:
 
 
 def get_ensembl_species(server: dict, meta_db: str) -> dict:
-
     """
     Query the metadata database for all Ensembl species and their assemblies.
 
@@ -150,13 +147,17 @@ def get_ensembl_species(server: dict, meta_db: str) -> dict:
     process = subprocess.run(
         [
             "mysql",
-            "--host", server["host"],
-            "--port", server["port"],
-            "--user", server["user"],
-            "--database", meta_db,
+            "--host",
+            server["host"],
+            "--port",
+            server["port"],
+            "--user",
+            server["user"],
+            "--database",
+            meta_db,
             "-N",
             "--execute",
-            query
+            query,
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -181,7 +182,6 @@ def get_ensembl_species(server: dict, meta_db: str) -> dict:
 
 
 def get_ensembl_vcf_filepaths(server: dict, meta_db: str) -> dict:
-
     """
     Retrieve file paths of already-prepared VCFs for Ensembl species.
 
@@ -224,21 +224,28 @@ def get_ensembl_vcf_filepaths(server: dict, meta_db: str) -> dict:
     process = subprocess.run(
         [
             "mysql",
-            "--host", server["host"],
-            "--port", server["port"],
-            "--user", server["user"],
-            "--database", meta_db,
+            "--host",
+            server["host"],
+            "--port",
+            server["port"],
+            "--user",
+            server["user"],
+            "--database",
+            meta_db,
             "-N",
-            "--execute", query
+            "--execute",
+            query,
         ],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+        stderr=subprocess.PIPE,
     )
 
     if process.returncode != 0:
-        print(f"[ERROR] Failed to retrieve Ensembl species - {process.stderr.decode().strip()}. \nExiting...")
+        print(
+            f"[ERROR] Failed to retrieve Ensembl species - {process.stderr.decode().strip()}. \nExiting..."
+        )
         exit(1)
-    
+
     ensembl_filepaths = {}
     for filepath_meta in process.stdout.decode().strip().split("\n"):
         (accession, production_name, genome_uuid, file_path) = filepath_meta.split()
@@ -252,7 +259,6 @@ def get_ensembl_vcf_filepaths(server: dict, meta_db: str) -> dict:
 
 
 def get_ensembl_variant_counts(server: dict, meta_db: str) -> dict:
-
     """
     Retrieve the count of short variants for each assembly.
 
@@ -287,15 +293,20 @@ def get_ensembl_variant_counts(server: dict, meta_db: str) -> dict:
     process = subprocess.run(
         [
             "mysql",
-            "--host", server["host"],
-            "--port", server["port"],
-            "--user", server["user"],
-            "--database", meta_db,
+            "--host",
+            server["host"],
+            "--port",
+            server["port"],
+            "--user",
+            server["user"],
+            "--database",
+            meta_db,
             "-N",
-            "--execute", query
+            "--execute",
+            query,
         ],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+        stderr=subprocess.PIPE,
     )
 
     if process.returncode != 0:
@@ -309,7 +320,7 @@ def get_ensembl_variant_counts(server: dict, meta_db: str) -> dict:
         (assembly, variant_count) = ensembl_variant_count.split()
         ensembl_variant_counts[assembly] = int(variant_count)
 
-    return(ensembl_variant_counts)
+    return ensembl_variant_counts
 
 
 def get_eva_version_from_ensembl_vcf(vcf_path: str):
@@ -335,8 +346,7 @@ def get_eva_version_from_ensembl_vcf(vcf_path: str):
 
     try:
         output = subprocess.check_output(
-            ["zgrep", "^##source=", str(vcf)],
-            stderr=subprocess.DEVNULL
+            ["zgrep", "^##source=", str(vcf)], stderr=subprocess.DEVNULL
         )
     except subprocess.CalledProcessError:
         return None
@@ -356,7 +366,6 @@ def get_eva_version_from_ensembl_vcf(vcf_path: str):
 
 
 def get_latest_eva_version() -> int:
-
     """
     Query the EVA REST API for the most recent release version.
 
@@ -389,11 +398,10 @@ def get_latest_eva_version() -> int:
 
 
 def get_eva_species(release_version: int) -> dict:
-
     """
     Fetch per-species statistics from EVA for a given release.
     Filters out species with fewer than 5,000 variants.
-    Gets other metadata, including the EVA VCF folder. 
+    Gets other metadata, including the EVA VCF folder.
 
     Parameters:
         release_version (int): EVA release to query.
@@ -444,11 +452,10 @@ def get_eva_species(release_version: int) -> dict:
 
 
 def seq_region_matches(eva_file: str, ensembl_file: str) -> bool:
-
     """
     Compare sequence regions between a remote EVA VCF and a local Ensembl VCF.
-    Retries up to 3 times when fetching remote regions to account for failed 
-    connection to the EVA API. 
+    Retries up to 3 times when fetching remote regions to account for failed
+    connection to the EVA API.
 
     Parameters:
         eva_file (str): Remote EVA VCF URL.
@@ -460,9 +467,9 @@ def seq_region_matches(eva_file: str, ensembl_file: str) -> bool:
     Exits:
         If tabix fails repeatedly on the EVA file.
     """
-    
+
     max_retries = 4
-    retry_delay = 60 # seconds
+    retry_delay = 60  # seconds
 
     # EVA VCF
     eva_seq_regs = None
@@ -490,9 +497,11 @@ def seq_region_matches(eva_file: str, ensembl_file: str) -> bool:
 
     # Couldn’t get EVA seqnames, throw warning and don't let check pass to be safe
     if eva_seq_regs is None:
-        print(f"[WARNING] Cannot check seqnames in {eva_file}; skipping seq‑region check.")
+        print(
+            f"[WARNING] Cannot check seqnames in {eva_file}; skipping seq‑region check."
+        )
         return False
-    
+
     # Clean up any temp EVA index files that have been generated in cwd
     for ext in [".tbi", ".csi"]:
         idx_file = os.path.basename(eva_file) + ext
@@ -523,7 +532,6 @@ def seq_region_matches(eva_file: str, ensembl_file: str) -> bool:
 
 
 def get_ensembl_release_status(server: dict, meta_db: str) -> str:
-
     """
     Retrieve genome release statuses ('prepared', 'planned') from metadata DB.
 
@@ -556,35 +564,45 @@ def get_ensembl_release_status(server: dict, meta_db: str) -> str:
     process = subprocess.run(
         [
             "mysql",
-            "--host", server["host"],
-            "--port", server["port"],
-            "--user", server["user"],
-            "--database", meta_db,
+            "--host",
+            server["host"],
+            "--port",
+            server["port"],
+            "--user",
+            server["user"],
+            "--database",
+            meta_db,
             "-N",
-            "--execute", query
+            "--execute",
+            query,
         ],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+        stderr=subprocess.PIPE,
     )
 
     if process.returncode != 0:
-        print(f"[ERROR] Failed to retrieve release status - {process.stderr.decode().strip()}. \nExiting...")
+        print(
+            f"[ERROR] Failed to retrieve release status - {process.stderr.decode().strip()}. \nExiting..."
+        )
         exit(1)
 
     ensembl_release_status = defaultdict(list)
     for release_meta in process.stdout.decode().strip().split("\n"):
         (production_name, accession, status, release_id) = release_meta.split()
-        ensembl_release_status[accession].append({
-            "species": re.sub(r'_gca.*$', '', production_name), # remove accession suffix
-            "release_status": status,
-            "release_id": release_id,
-        })
+        ensembl_release_status[accession].append(
+            {
+                "species": re.sub(
+                    r"_gca.*$", "", production_name
+                ),  # remove accession suffix
+                "release_status": status,
+                "release_id": release_id,
+            }
+        )
 
     return ensembl_release_status
 
 
 def main(args=None):
-
     """
     Discover species needing re-run of VCF-prepper.
 
@@ -599,18 +617,24 @@ def main(args=None):
     os.makedirs(args.output_dir, exist_ok=True)
 
     # Pull EVA metadata
-    eva_release             = get_latest_eva_version()
-    eva_species             = get_eva_species(eva_release)
+    eva_release = get_latest_eva_version()
+    eva_species = get_eva_species(eva_release)
 
     # Pull Ensembl metadata
-    server                  = parse_ini(args.ini_file, "metadata")
-    ensembl_species         = get_ensembl_species(server, meta_db="ensembl_genome_metadata")
-    ensembl_vcf_paths       = get_ensembl_vcf_filepaths(server, meta_db="ensembl_genome_metadata")
-    ensembl_status          = get_ensembl_release_status(server, meta_db="ensembl_genome_metadata")
-    ensembl_variant_counts  = get_ensembl_variant_counts(server, meta_db="ensembl_genome_metadata")
+    server = parse_ini(args.ini_file, "metadata")
+    ensembl_species = get_ensembl_species(server, meta_db="ensembl_genome_metadata")
+    ensembl_vcf_paths = get_ensembl_vcf_filepaths(
+        server, meta_db="ensembl_genome_metadata"
+    )
+    ensembl_status = get_ensembl_release_status(
+        server, meta_db="ensembl_genome_metadata"
+    )
+    ensembl_variant_counts = get_ensembl_variant_counts(
+        server, meta_db="ensembl_genome_metadata"
+    )
 
     # Get release_id for "Planned" and "Prepared"
-    planned_ids  = set()
+    planned_ids = set()
     prepared_ids = set()
     for recs in ensembl_status.values():
         for rec in recs:
@@ -624,21 +648,22 @@ def main(args=None):
     if len(prepared_ids) != 1:
         print(f"[WARN] expected exactly one 'prepared' release_id, got {prepared_ids}")
 
-    planned_release_id  = planned_ids.pop()  
+    planned_release_id = planned_ids.pop()
     prepared_release_id = prepared_ids.pop()
 
     # Prepare empty dicts
-    ensembl_prepared   = {}
-    ensembl_planned    = {}
-    eva_updates        = {}
+    ensembl_prepared = {}
+    ensembl_planned = {}
+    eva_updates = {}
 
     # Loop over only those assemblies present in BOTH Ensembl and EVA
     for asm in set(ensembl_species) & set(eva_species):
-
-        meta                    = ensembl_species[asm]
-        status                  = ensembl_status.get(asm)       # None or {"release_status": "...", "release_id": "..."}
-        vcf_meta                = ensembl_vcf_paths.get(asm)    # None or {"file_path": "..."}
-        eva_meta                = eva_species[asm]
+        meta = ensembl_species[asm]
+        status = ensembl_status.get(
+            asm
+        )  # None or {"release_status": "...", "release_id": "..."}
+        vcf_meta = ensembl_vcf_paths.get(asm)  # None or {"file_path": "..."}
+        eva_meta = eva_species[asm]
 
         sp = meta["species"]
         print(f"Processing: {asm}, for species: {sp}")
@@ -649,18 +674,20 @@ def main(args=None):
         if meta["species"].startswith("homo"):
             continue
 
-        # Build template 'record' dict 
+        # Build template 'record' dict
         release_folder = eva_meta["release_folder"]
-        tax_part       = str(eva_meta["taxonomy_id"]) + "_" if eva_release >= 5 else ""
-        file_loc       = os.path.join(release_folder, asm, f"{tax_part}{asm}_current_ids.vcf.gz")
+        tax_part = str(eva_meta["taxonomy_id"]) + "_" if eva_release >= 5 else ""
+        file_loc = os.path.join(
+            release_folder, asm, f"{tax_part}{asm}_current_ids.vcf.gz"
+        )
 
         record = {
-            "genome_uuid":   meta["genome_uuid"],
-            "species":       meta["species"],
-            "assembly":      meta["assembly_name"],
-            "source_name":   "EVA",
-            "file_type":     "remote",
-            "file_location": file_loc, # EVA file URL
+            "genome_uuid": meta["genome_uuid"],
+            "species": meta["species"],
+            "assembly": meta["assembly_name"],
+            "source_name": "EVA",
+            "file_type": "remote",
+            "file_location": file_loc,  # EVA file URL
         }
 
         # Check for genebuild/assembly candidates - candidates must have a planned, prepared or both statuses in the metdata db
@@ -674,34 +701,40 @@ def main(args=None):
                 if rs == "planned":
                     ensembl_planned.setdefault(genome_key, []).append(record)
 
-        # Check for EVA variant update candidates - only if we already have a VCF 
+        # Check for EVA variant update candidates - only if we already have a VCF
         if vcf_meta:
             vcf_path = vcf_meta["file_path"]
-            
+
             # If the current Ensembl EVA version can be grabbed from vcf header, grab and compare, otherwise revert to variant count comparison
             eva_ensembl_version = get_eva_version_from_ensembl_vcf(vcf_path=vcf_path)
 
-            update=False
-            if eva_ensembl_version: 
+            update = False
+            if eva_ensembl_version:
                 if eva_ensembl_version < eva_release:
                     update = True
             else:
                 if ensembl_variant_counts.get(asm, 0) < eva_meta["variant_count"]:
                     update = True
-            
+
             if update and seq_region_matches(eva_file=file_loc, ensembl_file=vcf_path):
                 genome_key = f"{meta['species']}_{meta['assembly_name']}"
                 eva_updates.setdefault(genome_key, []).append(record)
 
-    # Write the output JSON files 
-    with open(os.path.join(args.output_dir, f"ensembl_prepared_{prepared_release_id}.json"), "w") as out:
+    # Write the output JSON files
+    with open(
+        os.path.join(args.output_dir, f"ensembl_prepared_{prepared_release_id}.json"),
+        "w",
+    ) as out:
         json.dump(ensembl_prepared, out, indent=4)
 
-    with open(os.path.join(args.output_dir, f"ensembl_planned_{planned_release_id}.json"), "w") as out:
+    with open(
+        os.path.join(args.output_dir, f"ensembl_planned_{planned_release_id}.json"), "w"
+    ) as out:
         json.dump(ensembl_planned, out, indent=4)
 
     with open(os.path.join(args.output_dir, "eva_updates.json"), "w") as out:
         json.dump(eva_updates, out, indent=4)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+
+"""
+Auto-discover EVA-eligible species for the Ensembl beta VEP pipeline.
+Generates JSON configs of species requiring re-run based on genebuild status
+(or "planned"/"prepared") and EVA variant-count updates.
+"""
+
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import configparser
+import argparse
+import os
+import json
+import subprocess
+import requests
+import time
+import re
+from pathlib import Path
+
+## IMPORTANT: currently this script only supports EVA - we should update the output to have Ensembl data manually -
+# - triticum_aestivum
+# - triticum_turgidum
+# - vitis_vinifera
+# - solanum_lycopersicum
+# - ovis_aries_rambouillet
+# - canis_lupus_familiarisboxer
+## These species we can probably ignore until we have EVA data
+# - ornithorhynchus_anatinus
+# - monodelphis_domestica
+# - tetraodon_nigroviridis
+## Human will be manual as well
+
+
+EVA_REST_ENDPOINT = "https://www.ebi.ac.uk/eva/webservices/release"
+
+
+def parse_args(args=None):
+
+    """
+    Parse command-line arguments.
+
+    Parameters:
+        args (list[str], optional): List of arguments to parse (defaults to sys.argv).
+
+    Returns:
+        argparse.Namespace: Parsed arguments with attributes 'ini_file' and 'output_file'.
+    """
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "-I",
+        "--ini_file",
+        dest="ini_file",
+        type=str,
+        default="DEFAULT.ini",
+        required=False,
+        help="Config file with database server information",
+    )
+    parser.add_argument(
+        "-O",
+        "--output_file",
+        dest="output_file",
+        type=str,
+        default="input_config.json",
+        required=False,
+        help="Full path to output file",
+    )
+
+    return parser.parse_args(args)
+
+
+def parse_ini(ini_file: str, section: str = "database") -> dict:
+
+    """
+    Read database connection details from an INI file.
+
+    Parameters:
+        ini_file (str): Path to the INI file.
+        section (str): Section name in INI containing host/port/user keys.
+
+    Returns:
+        dict: {'host': str, 'port': str, 'user': str} from the INI.
+
+    Raises:
+        SystemExit: If the section is missing.
+    """
+
+    config = configparser.ConfigParser()
+    config.read(ini_file)
+
+    if not section in config:
+        print(f"[ERROR] Could not find '{section}' config in ini file - {ini_file}")
+        exit(1)
+    else:
+        host = config[section]["host"]
+        port = config[section]["port"]
+        user = config[section]["user"]
+
+    return {"host": host, "port": port, "user": user}
+
+
+def get_ensembl_species(server: dict, meta_db: str) -> str:
+
+    """
+    Query the metadata database for all Ensembl species and their assemblies.
+
+    Parameters:
+        server (dict): Connection info {'host','port','user'}.
+        meta_db (str): Name of the metadata database to query.
+
+    Returns:
+        dict: Mapping assembly accession -> {
+            'species': production_name,
+            'genome_uuid': uuid,
+            'assembly_name': default name
+        }
+
+    Exits:
+        On subprocess error.
+    """
+
+    query = f"""
+            SELECT 
+                g.genome_uuid, 
+                g.production_name, 
+                a.accession, 
+                a.assembly_default 
+            FROM genome AS g, assembly AS a 
+            WHERE g.assembly_id = a.assembly_id
+            """
+
+    process = subprocess.run(
+        [
+            "mysql",
+            "--host", server["host"],
+            "--port", server["port"],
+            "--user", server["user"],
+            "--database", meta_db,
+            "-N",
+            "--execute",
+            query
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    if process.returncode != 0:
+        print(
+            f"[ERROR] Failed to retrieve Ensembl species - {process.stderr.decode().strip()}. \nExiting..."
+        )
+        exit(1)
+
+    ensembl_species = {}
+    for species_meta in process.stdout.decode().strip().split("\n"):
+        (genome_uuid, species, assembly, assembly_default) = species_meta.split()
+        ensembl_species[assembly] = {
+            "species": species,
+            "genome_uuid": genome_uuid,
+            "assembly_name": assembly_default,
+        }
+
+    return ensembl_species
+
+
+def get_ensembl_vcf_filepaths(server: dict, meta_db: str) -> str:
+
+    """
+    Retrieve file paths of already-prepared VCFs for Ensembl species.
+
+    Parameters:
+        server (dict): Connection info {'host','port','user'}.
+        meta_db (str): Name of the metadata database.
+
+    Returns:
+        dict: Mapping assembly accession -> {
+            'species': production_name,
+            'genome_uuid': uuid,
+            'file_path': VCF file path
+        }
+
+    Exits:
+        On subprocess error.
+    """
+
+    query = f"""
+            SELECT 
+                a.accession,
+                g.production_name,
+                g.genome_uuid,
+                s.name as file_path
+            FROM dataset_source AS s
+            JOIN dataset AS d 
+            ON s.dataset_source_id = d.dataset_source_id
+            JOIN dataset_type AS t 
+            ON d.dataset_type_id = t.dataset_type_id
+            JOIN genome_dataset AS gd 
+            ON d.dataset_id = gd.dataset_id
+            JOIN genome AS g 
+            ON gd.genome_id = g.genome_id
+            JOIN assembly AS a
+            ON g.assembly_id = a.assembly_id
+            WHERE t.name = 'variation'
+            AND s.type = 'vcf';
+    """
+
+    process = subprocess.run(
+        [
+            "mysql",
+            "--host", server["host"],
+            "--port", server["port"],
+            "--user", server["user"],
+            "--database", meta_db,
+            "-N",
+            "--execute", query
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+    if process.returncode != 0:
+        print(f"[ERROR] Failed to retrieve Ensembl species - {process.stderr.decode().strip()}. \nExiting...")
+        exit(1)
+    
+    ensembl_filepaths = {}
+    for filepath_meta in process.stdout.decode().strip().split("\n"):
+        (accession, production_name, genome_uuid, file_path) = filepath_meta.split()
+        ensembl_filepaths[accession] = {
+            "species": production_name,
+            "genome_uuid": genome_uuid,
+            "file_path": file_path,
+        }
+
+    return ensembl_filepaths
+
+
+def count_ensembl_variants(ensembl_vcf_path: str) -> int:
+    """
+    Count non-header rows (n variants) in a gzipped VCF using zgrep.
+
+    Parameters:
+        ensembl_vcf_path (str): Path to a .vcf.gz file.
+
+    Returns:
+        int: Number of lines not starting with '#'.
+
+    Raises:
+        CalledProcessError: If zgrep invocation fails.
+    """
+
+    try:
+        # Run the zgrep command with subprocess.check_output to capture output
+        output = subprocess.check_output(
+            ["zgrep", "-vc", "^#", ensembl_vcf_path], stderr=subprocess.STDOUT
+        )
+        count = int(output.decode("utf-8").strip())
+        return count
+
+    except subprocess.CalledProcessError as e:
+        print("Error running zgrep command:", e.output.decode("utf-8"))
+        raise
+
+
+def get_eva_version_from_ensembl_vcf(vcf_path: str):
+    """
+    Extract the EVA version from the VCF header's ##source line and return it as an integer.
+
+    This function zgreps the compressed VCF for lines starting with "##source=",
+    filters for the one where source="EVA", parses out the version attribute and
+    casts it to int.
+
+    Parameters:
+        vcf_path (str): Path to the bgzipped VCF file.
+
+    Returns:
+        int | None: The EVA version as an integer if found and numeric, otherwise None.
+
+    Raises:
+        FileNotFoundError: If the specified VCF file does not exist.
+    """
+    vcf = Path(vcf_path)
+    if not vcf.exists():
+        raise FileNotFoundError(f"{vcf_path!r} does not exist")
+
+    try:
+        output = subprocess.check_output(
+            ["zgrep", "^##source=", str(vcf)],
+            stderr=subprocess.DEVNULL
+        )
+    except subprocess.CalledProcessError:
+        return None
+
+    for line in output.decode("utf-8").splitlines():
+        if 'source="EVA"' not in line:
+            continue
+        m = re.search(r'version="([^"]+)"', line)
+        if m:
+            version_str = m.group(1)
+            try:
+                return int(version_str)
+            except ValueError:
+                return None
+
+    return None
+
+
+def get_latest_eva_version() -> int:
+
+    """
+    Query the EVA REST API for the most recent release version.
+
+    Returns:
+        int: Latest EVA release number.
+
+    Exits:
+        On HTTP error or unexpected payload.
+    """
+
+    url = EVA_REST_ENDPOINT + "/v1/info/latest"
+    headers = {"Accept": "application/json"}
+
+    response = requests.get(url, headers=headers)
+
+    if response.status_code != 200:
+        print(
+            f"[ERROR] REST API call for retrieving EVA latest version failed with status - {response.status_code}. Exiting.."
+        )
+        exit(1)
+
+    try:
+        content = response.json()
+        release_version = content["releaseVersion"]
+    except:
+        print(f"[ERROR] Failed to retrieve EVA latest version. Exiting..")
+        exit(1)
+
+    return release_version
+
+
+def get_eva_species(release_version: int) -> dict:
+
+    """
+    Fetch per-species statistics from EVA for a given release.
+    Filters out species with fewer than 5,000 variants.
+    Gets other metadata, including the EVA VCF folder. 
+
+    Parameters:
+        release_version (int): EVA release to query.
+
+    Returns:
+        dict: Mapping assembly accession -> {
+            'species', 'accession', 'release_folder', 'taxonomy_id', 'variant_count'
+        }
+
+    Exits:
+        On HTTP error.
+    """
+
+    eva_species = {}
+
+    url = (
+        EVA_REST_ENDPOINT
+        + "/v2/stats/per-species?releaseVersion="
+        + str(release_version)
+    )
+    headers = {"Accept": "application/json"}
+
+    response = requests.get(url, headers=headers)
+    if response.status_code != 200:
+        print(
+            f"[ERROR] Could not get EVA species data; REST API call failed with status - {response.status_code}"
+        )
+        exit(1)
+
+    content = response.json()
+
+    for species in content:
+        if species["currentRs"] < 5000:
+            continue
+
+        for accession in species["assemblyAccessions"]:
+            new_assembly = {
+                "species": species["scientificName"],
+                "accession": accession,
+                "release_folder": species["releaseLink"] or None,
+                "taxonomy_id": species["taxonomyId"],
+                "variant_count": species["currentRs"],
+            }
+
+            eva_species[accession] = new_assembly
+
+    return eva_species
+
+
+def seq_region_matches(eva_file: str, ensembl_file: str) -> bool:
+
+    """
+    Compare sequence regions between a remote EVA VCF and a local Ensembl VCF.
+    Retries up to 3 times when fetching remote regions to account for failed 
+    connection to the EVA API. 
+
+    Parameters:
+        eva_file (str): Remote EVA VCF URL.
+        ensembl_file (str): Local VCF path.
+
+    Returns:
+        bool: True if any seq_region is common to both files.
+
+    Exits:
+        If tabix fails repeatedly on the EVA file.
+    """
+    
+    max_retries = 3
+    retry_delay = 10 # seconds
+
+    for attempt in range(max_retries):
+        process = subprocess.run(
+            ["tabix", "-D", eva_file, "-l"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        if process.returncode == 0:
+            break
+        else:
+            print(f"[WARNING] Attempt {attempt+1} of {max_retries} failed to retrieve seq regions from {eva_file}.")
+            print(f"Error: {process.stderr.decode().strip()}")
+            if attempt < max_retries - 1:
+                print(f"Retrying in {retry_delay} seconds...")
+                time.sleep(retry_delay)
+    else:
+        print(f"[ERROR] Failed to retrieve seq regions from {eva_file} after {max_retries} attempts.\nExiting...")
+        exit(1)
+
+    eva_seq_regions = process.stdout.decode().strip().split('\n')
+
+    # ENS file
+    process = subprocess.run(["tabix", "-D", ensembl_file, "-l"],
+        stdout = subprocess.PIPE,
+        stderr = subprocess.PIPE
+    )
+
+    if process.returncode != 0:
+        print(f"[ERROR] Failed to retrieve seq regions from - {ensembl_file} \nerror: {process.stderr.decode().strip()}. \nExiting...")
+        exit(1)
+
+    ensembl_seq_regions = process.stdout.decode().strip().split('\n')
+
+    # We accept only single seq region match
+    for seq_region in eva_seq_regions:
+        if seq_region in ensembl_seq_regions:
+            return True
+    return False
+
+
+def get_ensembl_release_status(server: dict, meta_db: str) -> str:
+
+    """
+    Retrieve genome release statuses ('prepared' or 'planned') from metadata DB.
+
+    Parameters:
+        server (dict): DB connection info.
+        meta_db (str): Metadata database name.
+
+    Returns:
+        dict: Mapping assembly accession -> {
+            'species', 'release_status', 'release_id'
+        }
+
+    Exits:
+        On subprocess error.
+    """
+
+    query = f"""
+            SELECT 
+                g.production_name,
+                a.accession,
+                er.status,
+                er.release_id
+            FROM genome AS g
+            JOIN assembly AS a ON g.assembly_id = a.assembly_id
+            JOIN genome_release AS gr ON gr.genome_id    = g.genome_id
+            JOIN ensembl_release AS er ON er.release_id  = gr.release_id
+            WHERE er.status IN ('prepared','planned');
+    """
+
+    process = subprocess.run(
+        [
+            "mysql",
+            "--host", server["host"],
+            "--port", server["port"],
+            "--user", server["user"],
+            "--database", meta_db,
+            "-N",
+            "--execute", query
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+    if process.returncode != 0:
+        print(f"[ERROR] Failed to retrieve release status - {process.stderr.decode().strip()}. \nExiting...")
+        exit(1)
+
+    ensembl_release_status = {}
+    for release_meta in process.stdout.decode().strip().split("\n"):
+        (production_name, accession, status, release_id) = release_meta.split()
+        ensembl_release_status[accession] = {
+            "species": re.sub(r'_gca.*$', '', production_name), # remove accession suffix
+            # "species": production_name,
+            "release_status": status,
+            "release_id": release_id,
+        }
+
+    return ensembl_release_status
+
+
+def main(args=None):
+
+    """
+    Main work: discover species needing re-run of VCF-prepper.
+
+    1) Query EVA and Ensembl metadata
+    2) Build candidate lists for:
+       - genebuild "planned" and "prepared" releases
+       - EVA-variant-count updates
+    3) Write out three JSON files accordingly
+    """
+
+    args = parse_args(args)
+
+    # Pull EVA metadata
+    eva_release       = get_latest_eva_version()
+    eva_species       = get_eva_species(eva_release)
+
+    # Pull Ensembl metadata
+    server            = parse_ini(args.ini_file, "metadata")
+    ensembl_species   = get_ensembl_species(server, meta_db="ensembl_genome_metadata")
+    ensembl_vcf_paths = get_ensembl_vcf_filepaths(server, meta_db="ensembl_genome_metadata")
+    ensembl_status    = get_ensembl_release_status(server, meta_db="ensembl_genome_metadata")
+
+    # Get release_id for "Planned" and "Prepared"
+    planned_release_id  = { meta["release_id"]
+                        for meta in ensembl_status.values()
+                        if meta["release_status"] == "Planned" }.pop()
+
+    prepared_release_id = { meta["release_id"]
+                        for meta in ensembl_status.values()
+                        if meta["release_status"] == "Prepared" }.pop()
+
+    # Prepare empty dicts
+    ensembl_prepared   = {}
+    ensembl_planned    = {}
+    eva_updates        = {}
+
+    # Loop over only those assemblies present in BOTH Ensembl and EVA
+    for asm in set(ensembl_species) & set(eva_species):
+
+        meta     = ensembl_species[asm]
+        status   = ensembl_status.get(asm)       # None or {"release_status": "...", "release_id": "..."}
+        vcf_meta = ensembl_vcf_paths.get(asm)    # None or {"file_path": "..."}
+        eva_meta = eva_species[asm]
+
+        sp = meta["species"]
+        print(f"Processing {asm}, where species is {sp}")
+
+        if status:
+            release_id = status.get("release_id")
+
+        # Skip human
+        if meta["species"].startswith("homo"):
+            continue
+
+        # Build template 'record' dict 
+        release_folder = eva_meta["release_folder"]
+        tax_part       = str(eva_meta["taxonomy_id"]) + "_" if eva_release >= 5 else ""
+        file_loc       = os.path.join(release_folder, asm, f"{tax_part}{asm}_current_ids.vcf.gz")
+
+        record = {
+            "genome_uuid":   meta["genome_uuid"],
+            "species":       meta["species"],
+            "assembly":      meta["assembly_name"],
+            "source_name":   "EVA",
+            "file_type":     "remote",
+            "file_location": file_loc, # EVA file URL
+        }
+
+        # Check for genebuild/assembly candidates - candidates must have a planned/prepared status in the metdata db
+        if status:
+            genome_key = f"{meta['species']}_{meta['assembly_name']}"
+
+            if status["release_status"] == "Prepared":
+                ensembl_prepared.setdefault(genome_key, []).append(record)
+
+            elif status["release_status"] == "Planned":
+                ensembl_planned.setdefault(genome_key, []).append(record)
+
+        # Check for EVA variant update candidates - only if we already have a VCF 
+        if vcf_meta:
+            vcf_path = vcf_meta["file_path"]
+            
+            # If the current Ensembl EVA version can be grabbed from vcf header, grab and compare, otherwise revert to variant count comparison
+            eva_ensembl_version = get_eva_version_from_ensembl_vcf(vcf_path=vcf_path)
+
+            update=False
+            if eva_ensembl_version: 
+                if eva_ensembl_version < eva_release:
+                    update = True
+            else:
+                ensembl_count = count_ensembl_variants(vcf_path)
+                if ensembl_count < eva_meta["variant_count"]:
+                    update = True
+            
+            if update and seq_region_matches(eva_file=file_loc, ensembl_file=vcf_path):
+                genome_key = f"{meta['species']}_{meta['assembly_name']}"
+                eva_updates.setdefault(genome_key, []).append(record)
+
+    # Write the output JSON files 
+    with open(f"ensembl_prepared_{prepared_release_id}.json", "w") as out:
+        json.dump(ensembl_prepared, out, indent=4)
+
+    with open(f"ensembl_planned_{planned_release_id}.json", "w") as out:
+        json.dump(ensembl_planned, out, indent=4)
+
+    with open(f"eva_updates.json", "w") as out:
+        json.dump(eva_updates, out, indent=4)
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

This PR adds a new script (`auto_discover_eva_species.py`) that automatically discovers which non-human species require a re-run of the VCF-prepper pipeline for our Ensembl beta VEP site. 

It:

1. Queries the EVA REST API to pull the latest per-species release statistics.  
2. Queries our Ensembl metadata database to retrieve:  
   - all species–assembly accessions and their existing VCF file paths  
   - “prepared” and “planned” genome build statuses (from the `ensembl_release` table)  
3. Compares EVA vs. Ensembl:  
   - **Genebuild candidates**—any species marked “prepared” or “planned” in Ensembl are flagged  
   - **EVA-count candidates**—for species already published, checks if the VCF header’s EVA version (or variant count as a fallback) is behind the latest EVA release  
4. Validates that sequence regions overlap before flagging  
5. Emits three JSON files:  
   - `ensembl_prepared_<release_id>.json`  
   - `ensembl_planned_<release_id>.json`  
   - `eva_updates.json`  

## Use case

Keeping variant data up-to-date for non-human species requires periodically re-running the `vcf_prepper` pipeline when the following conditions are met:

- A new Ensembl genebuild is deployed (“planned” or “prepared”)  
- EVA publishes more variants for a given species  

Manually tracking these changes is too time-consuming. 

## Testing

The script can be run with: 

```
python -u auto_create_input_config.py \
    --ini_file config.ini \
    --output_dir ./out \
    --tmp_dir ./out/tmp
```

Where config.ini looks like: 

```
[metadata]
host=***
port=***
user=***
name=***
```

## Benefits

- Automated detection of both genebuild and EVA updates  
- Removes the need to manually checking for which species to re-process
- Outputs JSONs that can be passed directly to VCF prepper
- Can be scheduled as a CRON job

## Possible Drawbacks

- The EVA REST API sometimes drops out (multiple 'tries' have been implemented to address this, hardcoded at `3` currently)
- The script is slightly slow at the moment due to the reliance on counting variants in EVA and Ensembl VCF files - this fallback will become redundant when this [PR](https://github.com/Ensembl/ensembl-hypsipyle/issues/27) is finalised and the script will run quicker. 

## TODO

- Initialise CRON job for this process. 