### PR TITLE
Small fix for edge case where planned or prepared have now rows in db

### DIFF
--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -730,7 +730,7 @@ def main(args=None):
     if prepared_ids:
         prepared_release_id = prepared_ids.pop()
     else:
-        planned_release_id = None
+        prepared_release_id = None
 
     # Prepare empty dicts
     ensembl_prepared = {}


### PR DESCRIPTION
Two small fixes: 

- Added in conditional logic for when planned or prepared status metadata db query yields no result - don't apply `.pop`, set variable to `None` and don't write JSON file, but **do** notify that this has occurred in the log file.  
- Prevent warning being thrown erroneously when `planned_ids.pop()` or `prepared_ids.pop()` evaluates to an empty set with length 0 - this was throwing a WARN that there were multiple unique IDs due to `!=1` 