### PR TITLE
Add/coerce Google-style docstrings

### DIFF
--- a/datachecks/conftest.py
+++ b/datachecks/conftest.py
@@ -21,6 +21,11 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 def pytest_addoption(parser):
+    """Add command-line options for test configuration.
+
+    Args:
+        parser (pytest.Parser): The parser used to add command-line options.
+    """
     parser.addoption("--vcf", type=str, default=None)
     parser.addoption("--bigbed", type=str, default=None)
     parser.addoption("--bigwig", type=str, default=None)
@@ -28,6 +33,11 @@ def pytest_addoption(parser):
     parser.addoption("--species", type=str, default=None)
 
 def pytest_generate_tests(metafunc):
+    """Parametrise tests with command-line options.
+
+    Args:
+        metafunc (pytest.Metafunc): The object used to generate tests.
+    """
     if "vcf" in metafunc.fixturenames:
         metafunc.parametrize("vcf", [metafunc.config.getoption("vcf")])
     if "bigbed" in metafunc.fixturenames:
@@ -41,15 +51,39 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture()
 def vcf_reader(vcf):
+    """Create a VCF reader fixture.
+
+    Args:
+        vcf (str): Path to the VCF file.
+
+    Returns:
+        cyvcf2.VCF: An instance of a VCF reader.
+    """
     vcf_reader = VCF(vcf)
     return vcf_reader
 
 @pytest.fixture()
 def bb_reader(bigbed):
+    """Create a BigBed reader fixture.
+
+    Args:
+        bigbed (str): Path to the BigBed file.
+
+    Returns:
+        pyBigWig: An instance of a BigBed reader.
+    """
     bb_reader = pyBigWig.open(bigbed)
     return bb_reader
 
 @pytest.fixture()
 def bw_reader(bigwig):
+    """Create a BigWig reader fixture.
+
+    Args:
+        bigwig (str): Path to the BigWig file.
+
+    Returns:
+        pyBigWig: An instance of a BigWig reader.
+    """
     bw_reader = pyBigWig.open(bigwig)
     return bw_reader

--- a/datachecks/helper.py
+++ b/datachecks/helper.py
@@ -15,6 +15,17 @@
 import logging
 
 def logAssert(test, msg):
+    """Log the result of a test assertion.
+
+    If the test condition is False, an error message is logged; otherwise, an informational message indicating a pass is logged.
+
+    Args:
+        test (bool): The condition to evaluate, where False indicates failure.
+        msg (str): The message to log.
+
+    Returns:
+        None
+    """
     if not test:
         logging.error("FAILED:", msg)
     else:

--- a/datachecks/run_datachecks.py
+++ b/datachecks/run_datachecks.py
@@ -30,6 +30,14 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 def parse_args(args = None):
+    """Parse command-line arguments.
+
+    Args:
+        args (list, optional): List of command-line arguments. Defaults to None.
+
+    Returns:
+        argparse.Namespace: The parsed command-line options.
+    """
     parser = argparse.ArgumentParser()
     
     parser.add_argument("--dir", dest="dir", type=str, default = os.getcwd())
@@ -44,6 +52,14 @@ def parse_args(args = None):
     return parser.parse_args(args)
 
 def get_species_metadata(input_config: str = None) -> dict:
+    """Retrieve species metadata from a configuration JSON file.
+
+    Args:
+        input_config (str, optional): Path to the input configuration file. Defaults to None.
+
+    Returns:
+        dict: A dictionary mapping genome UUIDs to species metadata. Returns an empty dict if the file is not found.
+    """
     if input_config is None or not os.path.isfile(input_config):
         return []
 
@@ -64,6 +80,14 @@ def get_species_metadata(input_config: str = None) -> dict:
     return species_metadata
 
 def is_valid_uuid(uuid: str):
+    """Check whether a string is a valid UUID.
+
+    Args:
+        uuid (str): The string to validate.
+
+    Returns:
+        bool: True if the string is a valid UUID, False otherwise.
+    """
     try:
         uuid_obj = UUID(uuid)
     except ValueError:
@@ -71,6 +95,17 @@ def is_valid_uuid(uuid: str):
     return str(uuid_obj) == uuid
 
 def main(args = None):
+    """Execute data checks and submit job scripts.
+
+    This function parses command-line arguments, reads species metadata from the input configuration,
+    and creates and submits job scripts for each genome.
+
+    Args:
+        args (list, optional): List of command-line arguments. Defaults to None.
+
+    Returns:
+        None
+    """
     args = parse_args(args)
 
     input_config = args.input_config or None

--- a/datachecks/test_bigbed.py
+++ b/datachecks/test_bigbed.py
@@ -20,14 +20,39 @@ import random
 class TestFile:
 
     def test_exist(self, bigbed):
+        """Check that the BigBed file exists.
+
+        Args:
+            bigbed (str): Path to the BigBed file.
+
+        Returns:
+            None
+        """
         assert os.path.isfile(bigbed)
 
     def test_validity(self, bb_reader):
+        """Check that the BigBed reader is valid.
+
+        Args:
+            bb_reader: An instance of a BigBed reader.
+
+        Returns:
+            None
+        """
         assert bb_reader.isBigBed()
+
 
 class TestSrcCount:
 
     def get_total_variant_count_from_vcf(self, vcf: str) -> int:
+        """Retrieve the total variant count from the VCF file using bcftools.
+
+        Args:
+            vcf (str): Path to the VCF file.
+
+        Returns:
+            int: The number of variants in the VCF file, or -1 if the file is not provided or the command fails.
+        """
         if vcf is None:
             logger.warning(f"Could not get variant count - no file provided")
             return -1
@@ -43,22 +68,53 @@ class TestSrcCount:
 
         return int(process.stdout.decode().strip())
 
-
     def get_total_variant_count_from_bb(self, bb_reader) -> int:
+        """Calculate the total variant count from a BigBed reader.
+
+        Args:
+            bb_reader: An instance of a BigBed reader.
+
+        Returns:
+            int: The sum of variant counts across all chromosomes.
+        """
         variant_counts = 0
         for chr in bb_reader.chroms():
             variant_counts += len(bb_reader.entries(chr, 0, bb_reader.chroms(chr)))
         return variant_counts
 
     def test_compare_count_with_source(self, vcf, bb_reader):
+        """Compare variant counts between VCF and BigBed sources.
+
+        Asserts that the variant count from BigBed is at least 95% of that from the VCF file.
+
+        Args:
+            vcf (str): Path to the VCF file.
+            bb_reader: An instance of a BigBed reader.
+
+        Returns:
+            None
+        """
         variant_count_vcf = self.get_total_variant_count_from_vcf(vcf)
         variant_count_bb = self.get_total_variant_count_from_bb(bb_reader)
 
         assert variant_count_bb > variant_count_vcf * 0.95
 
+
 class TestSrcExistence:
 
     def test_variant_exist_from_source(self, bb_reader, vcf_reader):
+        """Verify that variants extracted from the VCF file exist in the BigBed data.
+
+        The test randomly selects a number of variants from the VCF and checks if the corresponding entries
+        exist in the BigBed data.
+
+        Args:
+            bb_reader: An instance of a BigBed reader.
+            vcf_reader: An instance of a VCF reader.
+
+        Returns:
+            None
+        """
         NO_VARIANTS = 100
         NO_ITER = 100000
         

--- a/datachecks/test_bigwig.py
+++ b/datachecks/test_bigwig.py
@@ -20,14 +20,40 @@ import random
 class TestFile:
 
     def test_exist(self, bigwig):
+        """Check that the BigWig file exists.
+
+        Args:
+            bigwig (str): Path to the BigWig file.
+
+        Returns:
+            None
+        """
         assert os.path.isfile(bigwig)
 
     def test_validity(self, bw_reader):
+        """Verify that the BigWig reader is valid.
+
+        Args:
+            bw_reader: An instance of a BigWig reader.
+
+        Returns:
+            None
+        """
         assert bw_reader.isBigWig()
+
 
 class TestSrcExistence:
 
     def test_variant_exist_from_source(self, bw_reader, vcf_reader):
+        """Validate that variants from the VCF source exist in the BigWig data.
+
+        Args:
+            bw_reader: An instance of a BigWig reader.
+            vcf_reader: An instance of a VCF reader.
+
+        Returns:
+            None
+        """
         NO_VARIANTS = 100
         NO_ITER = 100000
         
@@ -53,9 +79,18 @@ class TestSrcExistence:
             bw_state = bw_reader.stats(chr, start, end)[0]
             assert bw_state > 0.0
 
+
 class TestSrcCount:
 
     def get_total_variant_count_from_vcf(self, vcf: str) -> int:
+        """Retrieve the total number of variants from the VCF file using bcftools.
+
+        Args:
+            vcf (str): Path to the VCF file.
+
+        Returns:
+            int: The number of variants, or -1 if the VCF file is not provided or the command fails.
+        """
         if vcf is None:
             logger.warning(f"Could not get variant count - no file provided")
             return -1
@@ -71,8 +106,15 @@ class TestSrcCount:
 
         return int(process.stdout.decode().strip())
 
-
     def get_total_variant_count_from_bw(self, bw_reader) -> int:
+        """Calculate the total variant count from the BigWig reader.
+
+        Args:
+            bw_reader: An instance of a BigWig reader.
+
+        Returns:
+            int: The sum of counts from non-zero BigWig values across all chromosomes.
+        """
         variant_counts = 0
         for chr in bw_reader.chroms():
             non_zero_vals = [val for val in bw_reader.values(chr, 0, bw_reader.chroms(chr)) if val > 0.0]
@@ -80,6 +122,17 @@ class TestSrcCount:
         return variant_counts
 
     def test_compare_count_with_source(self, vcf, bw_reader):
+        """Compare variant counts between the VCF and BigWig data sources.
+
+        Asserts that the variant count from BigWig is at least 95% of that from the VCF file.
+
+        Args:
+            vcf (str): Path to the VCF file.
+            bw_reader: An instance of a BigWig reader.
+
+        Returns:
+            None
+        """
         variant_count_vcf = self.get_total_variant_count_from_vcf(vcf)
         variant_count_bw = self.get_total_variant_count_from_bw(bw_reader)
 

--- a/nextflow/vcf_prepper/bin/generate_chrom_sizes.py
+++ b/nextflow/vcf_prepper/bin/generate_chrom_sizes.py
@@ -23,6 +23,14 @@ import os
 from helper import parse_ini, get_db_name
 
 def parse_args(args = None):
+    """Parse command-line arguments for generating the chromosome sizes file.
+
+    Args:
+        args (Optional[Iterable[str]]): List of command-line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed command-line arguments.
+    """
     parser = argparse.ArgumentParser()
     
     parser.add_argument(dest="species", type=str, help="species production name")
@@ -35,6 +43,19 @@ def parse_args(args = None):
     return parser.parse_args(args)
 
 def generate_chrom_sizes(server: dict, core_db: str, chrom_sizes: str, assembly: str = "grch38", force: bool = False) -> None:
+    """Generate a chromosome sizes file using core database information.
+
+    This function queries the database for coordinate system IDs and sequence regions,
+    appends synonyms, removes duplicates and writes the chromosome sizes to file,
+    incrementing each length by 1.
+
+    Args:
+        server (dict): Database server configuration.
+        core_db (str): Core database name.
+        chrom_sizes (str): Output file path to write chromosome sizes.
+        assembly (str, optional): Assembly version string. Defaults to "grch38".
+        force (bool, optional): Whether to force file creation if it exists. Defaults to False.
+    """
     if os.path.exists(chrom_sizes) and not force:
         print(f"[INFO] {chrom_sizes} file already exists, skipping ...")
         return
@@ -104,6 +125,17 @@ def generate_chrom_sizes(server: dict, core_db: str, chrom_sizes: str, assembly:
             file.write(f"{name}\t{str(length)}\n")
 
 def main(args = None):
+    """Main entry point for generating the chromosome sizes file.
+
+    Parses the arguments, retrieves the core database configuration and
+    generates the chromosome sizes file.
+
+    Args:
+        args (Optional[Iterable[str]]): List of command-line arguments.
+
+    Returns:
+        int: Exit status.
+    """
     args = parse_args(args)
     
     species = args.species

--- a/nextflow/vcf_prepper/bin/generate_synonym_file.py
+++ b/nextflow/vcf_prepper/bin/generate_synonym_file.py
@@ -23,6 +23,14 @@ import os
 from helper import parse_ini, get_db_name
 
 def parse_args(args = None):
+    """Parse command-line arguments for generating a chromosome synonym file.
+
+    Args:
+        args (Optional[Iterable[str]]): Command-line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed arguments.
+    """
     parser = argparse.ArgumentParser()
     
     parser.add_argument(dest="species", type=str, help="species production name")
@@ -35,6 +43,17 @@ def parse_args(args = None):
     return parser.parse_args(args)
 
 def generate_synonym_file(server: dict, core_db: str, synonym_file: str, force: bool = False) -> None:
+    """Generate a chromosome synonym file from the core database.
+
+    Retrieves synonyms and corresponding seq region names and writes them to a file,
+    ensuring names do not exceed 31 characters.
+
+    Args:
+        server (dict): Database server configuration.
+        core_db (str): Core database name.
+        synonym_file (str): Output file path for synonyms.
+        force (bool): If True, force regeneration even if the file exists.
+    """
     if os.path.exists(synonym_file) and not force:
         print(f"[INFO] {synonym_file} file already exists, skipping ...")
         return
@@ -99,6 +118,16 @@ def generate_synonym_file(server: dict, core_db: str, synonym_file: str, force: 
             file.write(f"{synonym}\t{new_names[synonym]}\n")
     
 def main(args = None):
+    """Main entry point for generating a sequence region synonym file.
+
+    Parses command-line arguments, connects to the core database, and writes the synoynm file.
+
+    Args:
+        args (Optional[Iterable[str]]): Command-line arguments.
+
+    Returns:
+        int: Exit code.
+    """
     args = parse_args(args)
     
     species = args.species

--- a/nextflow/vcf_prepper/bin/process_cache.py
+++ b/nextflow/vcf_prepper/bin/process_cache.py
@@ -27,6 +27,14 @@ from helper import *
 CACHE_DIR = "/nfs/production/flicek/ensembl/variation/data/VEP/tabixconverted"
 
 def parse_args(args = None):
+    """Parse command-line arguments for processing the VEP cache.
+
+    Args:
+        args (Optional[Iterable[str]]): List of command-line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed arguments.
+    """
     parser = argparse.ArgumentParser()
     
     parser.add_argument(dest="species", type=str, help="species production name")
@@ -40,6 +48,15 @@ def parse_args(args = None):
     return parser.parse_args(args)
     
 def uncompress_cache(cache_dir: str, compressed_cache: str) -> None:
+    """Uncompress a tar.gz cache file into the specified cache directory.
+
+    Args:
+        cache_dir (str): Directory where the cache should be uncompressed.
+        compressed_cache (str): Path to the compressed cache file.
+
+    Raises:
+        SystemExit: If uncompression fails.
+    """
     process = subprocess.run(["tar", "-xvzf", compressed_cache, "-C", cache_dir],
         stdout = subprocess.PIPE,
         stderr = subprocess.PIPE
@@ -50,6 +67,17 @@ def uncompress_cache(cache_dir: str, compressed_cache: str) -> None:
         exit(1)
     
 def main(args = None):
+    """Main entry point for processing the VEP cache.
+
+    Checks if the genome cache directory exists and, if forced or absent, retrieves and uncompresses
+    the cache using FTP.
+
+    Args:
+        args (Optional[Iterable[str]]): List of command-line arguments.
+
+    Returns:
+        int: Exit status.
+    """
     args = parse_args(args)
     
     species = args.species

--- a/nextflow/vcf_prepper/bin/process_conservation_data.py
+++ b/nextflow/vcf_prepper/bin/process_conservation_data.py
@@ -28,6 +28,14 @@ from helper import *
 CONSERVATION_DATA_DIR = "/nfs/production/flicek/ensembl/variation/data/Conservation"
 
 def parse_args(args = None):
+    """Parse command-line arguments for processing conservation data.
+
+    Args:
+        args (Optional[Iterable[str]]): List of command-line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed arguments.
+    """
     parser = argparse.ArgumentParser()
     
     parser.add_argument(dest="species", type=str, help="species production name")
@@ -41,6 +49,17 @@ def parse_args(args = None):
     return parser.parse_args(args)
         
 def main(args = None):
+    """Main entry point for processing conservation data.
+
+    This function obtains the necessary parameters, checks for an existing conservation
+    bigwig file and if not present (or forced), retrieves it via FTP.
+
+    Args:
+        args (Optional[Iterable[str]]): List of command-line arguments.
+
+    Returns:
+        int: Exit status.
+    """
     args = parse_args(args)
     
     species = args.species

--- a/nextflow/vcf_prepper/bin/summary_stats.py
+++ b/nextflow/vcf_prepper/bin/summary_stats.py
@@ -58,6 +58,15 @@ SKIP_CONSEQUENCE = [
 ]
 
 def parse_args(args = None, description: bool = None):
+    """Parse command-line arguments for generating summary statistics from a VCF.
+
+    Args:
+        args (Optional[Iterable[str]]): Command-line arguments.
+        description (Optional[bool]): Description for the argument parser.
+
+    Returns:
+        argparse.Namespace: Parsed command-line arguments.
+    """
     parser = argparse.ArgumentParser(description = description)
     
     parser.add_argument(dest="species", type=str, help="species production name")
@@ -69,6 +78,15 @@ def parse_args(args = None, description: bool = None):
     return parser.parse_args(args)
 
 def header_match(want_header: dict, got_header: dict) -> bool:
+    """Check whether a given header from the VCF matches the expected header.
+
+    Args:
+        want_header (dict): The expected header field properties.
+        got_header (dict): The header field extracted from the VCF.
+
+    Returns:
+        bool: True if the header matches; otherwise False.
+    """
     got_header.pop("IDX")
 
     return want_header['ID'] == got_header['ID'] and \
@@ -77,6 +95,15 @@ def header_match(want_header: dict, got_header: dict) -> bool:
         f'"{ want_header["Description"] }"' == got_header['Description']
 
 def minimise_allele(ref: str, alts: list) -> str:
+    """Minimise the allele representation by removing redundant bases.
+
+    Args:
+        ref (str): The reference allele.
+        alts (list): List of alternative alleles.
+
+    Returns:
+        tuple: The minimised reference allele and updated alternative alleles.
+    """
     alleles = [ref] + alts
     first_bases = {allele[0] for allele in alleles}
 
@@ -94,6 +121,18 @@ def minimise_allele(ref: str, alts: list) -> str:
     return (ref, alts)
 
 def main(args = None):
+    """Main entry point for generating summary statistics for a VCF file.
+
+    This function processes the input VCF file, adds necessary header and INFO fields,
+    calculates various statistics per allele and per variant, and writes the summary to
+    an output VCF.
+
+    Args:
+        args (Optional[Iterable[str]]): Command-line arguments.
+
+    Returns:
+        int: Exit code.
+    """
     args = parse_args(args)
 
     species = args.species

--- a/nextflow/vcf_prepper/bin/update_fields.py
+++ b/nextflow/vcf_prepper/bin/update_fields.py
@@ -33,6 +33,15 @@ VARIATION_SOURCE_DUMP_FILENAME = "variation_source.txt"
 
 
 def parse_args(args = None, description: bool = None):
+    """Parse command-line arguments for updating VCF fields.
+
+    Args:
+        args (Optional[Iterable[str]]): Command-line arguments.
+        description (Optional[bool]): Description for the argument parser.
+
+    Returns:
+        argparse.Namespace: Parsed command-line arguments.
+    """
     parser = argparse.ArgumentParser(description = description)
     
     parser.add_argument(dest="input_file", type=str, help="Input VCF file")
@@ -47,6 +56,17 @@ def parse_args(args = None, description: bool = None):
     return parser.parse_args(args)
 
 def format_clinvar_id(id: str) -> str:
+    """Format a ClinVar identifier by ensuring it has the proper structure.
+
+    If the identifier does not begin with "VCV", it pads the number with zeros so that
+    the numeric part is 9 characters long.
+
+    Args:
+        id (str): The original ClinVar identifier.
+
+    Returns:
+        str: The formatted ClinVar identifier.
+    """
     if not id.startswith("VCV"):
         leading_zero = 9 - len(id)
         return "VCV" + ("0" * leading_zero) + id
@@ -54,6 +74,19 @@ def format_clinvar_id(id: str) -> str:
     return id
 
 def format_meta(meta: str, chromosomes: str = None, synonyms: list = None) -> str:
+    """Format a VCF meta header with contig entries for specified chromosomes.
+
+    If chromosome information is provided, a contig header is added for each chromosome,
+    mapping via synonyms if available.
+
+    Args:
+        meta (str): The base meta header.
+        chromosomes (Optional[str]): Comma separated list of chromosomes.
+        synonyms (Optional[list]): Dictionary mapping chromosomes to synonyms.
+
+    Returns:
+        str: The updated meta header.
+    """
     if chromosomes is None:
         return meta
 
@@ -63,6 +96,11 @@ def format_meta(meta: str, chromosomes: str = None, synonyms: list = None) -> st
     return meta
 
 def process_variant_source() -> dict:
+    """Process the variation source file and build a mapping of variant names to sources.
+
+    Returns:
+        dict: Mapping from variant name to its source.
+    """
     variant_source = {}
     with open(VARIATION_SOURCE_DUMP_FILENAME, "r") as file:
         for line in file:
@@ -72,6 +110,16 @@ def process_variant_source() -> dict:
     return variant_source
 
 def main(args = None):
+    """Main entry point for updating VCF fields.
+
+    This function parses arguments, processes the input VCF file and writes a new VCF with updated fields.
+    
+    Args:
+        args (Optional[Iterable[str]]): Command-line arguments.
+    
+    Returns:
+        int: Exit code.
+    """
     args = parse_args(args)
 
     input_file = args.input_file

--- a/scripts/calculate_frequency_from_gt.py
+++ b/scripts/calculate_frequency_from_gt.py
@@ -44,6 +44,15 @@ base_outdir = args.base_outdir or "/nfs/production/flicek/ensembl/variation/new_
 write_output = args.write_output
 
 def parse_ini(ini_file: str, section: str = "database") -> dict:
+    """Parse the INI file and return database connection parameters.
+
+    Args:
+        ini_file (str): Path to the INI file.
+        section (str, optional): Configuration section to use. Defaults to "database".
+
+    Returns:
+        dict: Dictionary with host, port and user.
+    """
     config = configparser.ConfigParser()
     config.read(ini_file)
     
@@ -62,6 +71,17 @@ def parse_ini(ini_file: str, section: str = "database") -> dict:
     }
 
 def get_db_name(server: dict, version: str, species: str, type: str) -> str:
+    """Retrieve the name of the database for a given species and type.
+
+    Args:
+        server (dict): Server connection details.
+        version (str): Ensembl version.
+        species (str): Species name.
+        type (str): Type of database (e.g. 'variation').
+
+    Returns:
+        str: Database name.
+    """
     query = f"SHOW DATABASES LIKE '{species}_{type}%{version}%';"
     process = subprocess.run(["mysql",
             "--host", server["host"],
@@ -81,6 +101,15 @@ def get_db_name(server: dict, version: str, species: str, type: str) -> str:
     return results[0]
 
 def get_population_against_id(server: dict, variation_db: str) -> str:
+    """Map population IDs to their names from the population table.
+
+    Args:
+        server (dict): Server connection parameters.
+        variation_db (str): Variation database name.
+
+    Returns:
+        str: Dictionary mapping population IDs to names.
+    """
     query = f"SELECT population_id, name from population;"
     process = subprocess.run(["mysql",
             "--host", server["host"],
@@ -105,6 +134,15 @@ def get_population_against_id(server: dict, variation_db: str) -> str:
     return populations
 
 def get_population_structure(server: dict, variation_db: str) -> str:
+    """Retrieve the population structure mapping from the database.
+
+    Args:
+        server (dict): Server connection parameters.
+        variation_db (str): Variation database name.
+
+    Returns:
+        str: Mapping of sub_population_id to super_population_id.
+    """
     query = f"SELECT super_population_id, sub_population_id from population_structure;"
     process = subprocess.run(["mysql",
             "--host", server["host"],
@@ -129,6 +167,15 @@ def get_population_structure(server: dict, variation_db: str) -> str:
     return super_population
 
 def get_sample_against_id(server: dict, variation_db: str) -> str:
+    """Map sample IDs to sample names from the sample table.
+
+    Args:
+        server (dict): Server connection parameters.
+        variation_db (str): Variation database name.
+
+    Returns:
+        str: Dictionary mapping sample IDs to names.
+    """
     query = f"SELECT sample_id, name from sample;"
     process = subprocess.run(["mysql",
             "--host", server["host"],
@@ -153,6 +200,15 @@ def get_sample_against_id(server: dict, variation_db: str) -> str:
     return samples
 
 def get_sample_populations(server: dict, variation_db: str) -> str:
+    """Retrieve sample to population mappings from the sample_population table.
+
+    Args:
+        server (dict): Server connection parameters.
+        variation_db (str): Variation database name.
+
+    Returns:
+        str: Dictionary mapping sample IDs to list of population IDs.
+    """
     query = f"SELECT sample_id, population_id from sample_population;"
     process = subprocess.run(["mysql",
             "--host", server["host"],
@@ -179,6 +235,15 @@ def get_sample_populations(server: dict, variation_db: str) -> str:
     return sample_populations
 
 def generate_sample_population(server: dict, variation_db: str) -> dict:
+    """Generate a mapping of sample names to their populations with names.
+
+    Args:
+        server (dict): Server connection parameters.
+        variation_db (str): Variation database name.
+
+    Returns:
+        dict: Mapping of sample names to a list of population names.
+    """
     populations = get_population_against_id(server, variation_db)
     samples = get_sample_against_id(server, variation_db)
     sample_populations = get_sample_populations(server, variation_db)

--- a/scripts/create_metadata_payload.py
+++ b/scripts/create_metadata_payload.py
@@ -25,6 +25,14 @@ from uuid import UUID
 from cyvcf2 import VCF
 
 def parse_args(args = None):
+    """Parse command-line arguments for the metadata payload.
+
+    Args:
+        args (list, optional): List of command-line arguments. Defaults to None.
+
+    Returns:
+        argparse.Namespace: Parsed arguments.
+    """
     parser = argparse.ArgumentParser()
     
     parser.add_argument("--api_outdir", dest="api_outdir", type=str, help="path to a vcf prepper api output directory")
@@ -36,6 +44,14 @@ def parse_args(args = None):
     return parser.parse_args(args)
 
 def is_valid_uuid(uuid: str):
+    """Determine whether the provided UUID string is valid.
+
+    Args:
+        uuid (str): UUID string to check.
+
+    Returns:
+        bool: True if valid, False otherwise.
+    """
     try:
         uuid_obj = UUID(uuid)
     except ValueError:
@@ -43,6 +59,14 @@ def is_valid_uuid(uuid: str):
     return str(uuid_obj) == uuid
 
 def get_variant_count(file: str) -> str:
+    """Obtain the total variant count from a VCF file via bcftools.
+
+    Args:
+        file (str): Path to the VCF file.
+
+    Returns:
+        int or None: Number of records or None on failure.
+    """
     process = subprocess.run(["bcftools", "index", "--nrecords", file],
         stdout = subprocess.PIPE,
         stderr = subprocess.PIPE
@@ -56,6 +80,15 @@ def get_variant_count(file: str) -> str:
         return None
 
 def get_csq_field_index(csq: str, field: str ="Consequence") -> int:
+    """Get the index of the specified field in the CSQ annotation.
+
+    Args:
+        csq (str): CSQ header description.
+        field (str, optional): Field to search for. Defaults to "Consequence".
+
+    Returns:
+        int or None: The index of the field or None if not found.
+    """
     prefix = "Consequence annotations from Ensembl VEP. Format: "
     csq_list = csq[len(prefix):].split("|")
 
@@ -66,6 +99,15 @@ def get_csq_field_index(csq: str, field: str ="Consequence") -> int:
     return None
 
 def get_variant_example(file: str, species: str) -> str:
+    """Find an example variant from the VCF file.
+
+    Args:
+        file (str): Path to the VCF file.
+        species (str): Species identifier.
+
+    Returns:
+        str: A string representing a variant example in 'chrom:pos:id' format.
+    """
     vcf = VCF(file)
     
     csq_info_description = vcf.get_header_type("CSQ")["Description"].strip("\"")
@@ -100,6 +142,15 @@ def get_variant_example(file: str, species: str) -> str:
         return f"{chrom}:{pos}:{id}"
 
 def get_evidence_count(file: str, csq_field: str) -> int:
+    """Count evidence occurrences for a given field in the VCF file.
+
+    Args:
+        file (str): Path to the VCF file.
+        csq_field (str): CSQ field to search for.
+
+    Returns:
+        int or None: Count value or None if no positive count.
+    """
     vcf = VCF(file)
     
     csq_info_description = vcf.get_header_type("CSQ")["Description"].strip("\"")
@@ -124,6 +175,14 @@ def get_evidence_count(file: str, csq_field: str) -> int:
     return count
 
 def parse_input_config(input_config: str) -> dict:
+    """Parse the input config JSON file and extract species metadata.
+
+    Args:
+        input_config (str): Path to the input config JSON file.
+
+    Returns:
+        dict: Dictionary of species metadata keyed by genome_uuid.
+    """
     if not os.path.isfile(input_config):
         return []
 
@@ -143,9 +202,26 @@ def parse_input_config(input_config: str) -> dict:
     return species_metadata
 
 def submit_payload(endpoint: str, payload: str) -> str:
+    """Submit the JSON payload to the provided endpoint.
+
+    Args:
+        endpoint (str): Metadata API URL.
+        payload (str): JSON payload to submit.
+
+    Returns:
+        str: API response (if any).
+    """
     requests.put(endpoint, payload)
     
 def main(args = None):
+    """Main entry point to create and submit the metadata payload.
+
+    Args:
+        args (list, optional): List of command-line arguments. Defaults to None.
+
+    Returns:
+        int: Exit status.
+    """
     args = parse_args(args)
     
     api_outdir = args.api_outdir or os.getcwd()

--- a/scripts/create_track_api_metadata.py
+++ b/scripts/create_track_api_metadata.py
@@ -26,6 +26,14 @@ from cyvcf2 import VCF
 import re
 
 def parse_args(args = None):
+    """Parse command-line arguments.
+
+    Args:
+        args (list, optional): List of command-line arguments. Defaults to None.
+
+    Returns:
+        argparse.Namespace: Parsed arguments.
+    """
     parser = argparse.ArgumentParser()
     
     parser.add_argument("--tracks_outdir", dest="tracks_outdir", type=str, required = True, help="path to a vcf prepper tracks output directory")
@@ -34,6 +42,14 @@ def parse_args(args = None):
     return parser.parse_args(args)
 
 def is_valid_uuid(uuid: str):
+    """Check if a UUID string is valid.
+
+    Args:
+        uuid (str): UUID string to validate.
+
+    Returns:
+        bool: True if valid, False otherwise.
+    """
     try:
         uuid_obj = UUID(uuid)
     except ValueError:
@@ -41,6 +57,14 @@ def is_valid_uuid(uuid: str):
     return str(uuid_obj) == uuid
 
 def parse_input_config(input_config: str) -> dict:
+    """Parse the input config JSON file and extract species metadata.
+
+    Args:
+        input_config (str): Path to the input config JSON file.
+
+    Returns:
+        dict: A dictionary with genome_uuid as keys and metadata as values.
+    """
     if not os.path.isfile(input_config):
         return []
 
@@ -77,6 +101,31 @@ def get_source_header(api_file: str) -> dict:
     return source_info
 
 def get_source_desc_prefix(source: str, source_version: str) -> str:
+def get_source_info(source: str) -> str:
+    """Return a descriptive string for the given source.
+
+    Args:
+        source (str): Source identifier.
+
+    Returns:
+        str: Human-readable description of the source.
+    """
+    if source == "dbSNP":
+        return "dbSNP - build 156"
+    elif source == "EVA":
+        return "European Variation Archive (EVA) - release 5"
+    elif source == "Ensembl":
+        return "Ensembl - e110"
+
+def get_source_url(source: str) -> str:
+    """Return the URL associated with the given source.
+
+    Args:
+        source (str): Source identifier.
+
+    Returns:
+        str: URL for the source.
+    """
     if source == "dbSNP":
         return f" from dbSNP - build {source_version}"
     elif source == "EVA":
@@ -92,6 +141,14 @@ def get_source_desc_prefix(source: str, source_version: str) -> str:
         return desc_prefix
     
 def main(args = None):
+    """Main entry point for creating track API metadata.
+
+    Args:
+        args (list, optional): List of command-line arguments. Defaults to None.
+
+    Returns:
+        int: Exit status.
+    """
     args = parse_args(args)
     
     input_config = args.input_config


### PR DESCRIPTION
This PR affects all *.py files in the repo. 

For every function, either a Google-style docstring is added, or an existing docstring is improved and coerced into Google-style. 

To do this I used VSCode + GitHub Copilot: 
- I used Copilot in 'Edit' mode with ChatGPT model o3-mini. 
- For each directory containing .py files, I set the 'context' as the directory's path, and found that the following prompt delivered the best results: 

> For all .py files:
For functions with no docstring, analyse the function and add a suitable Google-style docstring. If the function has a docstring, improve it and coerce it into a Google-style docstring. Do not change any code or code formatting. Use UK English.

- I then scanned through each suggestion and accepted if it was sensible and contextually correct. 