### PR TITLE
Fix overlapping write to same file in no split mode

### DIFF
--- a/scripts/population_to_haplotype.py
+++ b/scripts/population_to_haplotype.py
@@ -87,10 +87,14 @@ writers['short_variant'] = {
     gt_idx: Writer(os.path.join(out_dir, filename), input_vcf) 
     for gt_idx, filename in filenames['short_variant'].items()
 }
-writers['structural_variant'] = {
-    gt_idx: Writer(os.path.join(out_dir, filename), input_vcf) 
-    for gt_idx, filename in filenames['structural_variant'].items()
-}
+# Separate files only in split mode, else point to the same writer objects
+if args.split_sv:
+    writers['structural_variant'] = {
+        gt_idx: Writer(os.path.join(out_dir, filename), input_vcf) 
+        for gt_idx, filename in filenames['structural_variant'].items()
+    }
+else:
+    writers['structural_variant'] = writers['short_variant']
 
 sample_idx = input_vcf.samples.index(sample)
 counter = 100


### PR DESCRIPTION
This addresses ENSVAR 6870, fixing an issue where when NOT using `--split_sv` mode, the same file was being written to by two `cyvcf2.Writer`s. 

Previously both "short" and "structural" writers pointed at the same file path, leading to overlapping writes and invalid/unsorted VCF. Now the no-split mode points both classes to the same writer object.