### PR TITLE
Add Google-style docstrings to all .py files

### DIFF
--- a/datachecks/conftest.py
+++ b/datachecks/conftest.py
@@ -22,6 +22,10 @@ logger.setLevel(logging.INFO)
 
 
 def pytest_addoption(parser):
+    """Add custom pytest command-line options.
+
+    Adds options to supply paths to vcf, bigbed, bigwig, source_vcf and species.
+    """
     parser.addoption("--vcf", type=str, default=None)
     parser.addoption("--bigbed", type=str, default=None)
     parser.addoption("--bigwig", type=str, default=None)
@@ -30,6 +34,10 @@ def pytest_addoption(parser):
 
 
 def pytest_generate_tests(metafunc):
+    """Parametrise fixtures from provided command-line options.
+
+    For each known fixture name, set a single parameterised value from the CLI option.
+    """
     if "vcf" in metafunc.fixturenames:
         metafunc.parametrize("vcf", [metafunc.config.getoption("vcf")])
     if "bigbed" in metafunc.fixturenames:
@@ -44,17 +52,20 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture()
 def vcf_reader(vcf):
+    """Provide a cyvcf2 VCF reader for the supplied VCF file path."""
     vcf_reader = VCF(vcf)
     return vcf_reader
 
 
 @pytest.fixture()
 def bb_reader(bigbed):
+    """Provide a pyBigWig reader opened on a bigBed file path."""
     bb_reader = pyBigWig.open(bigbed)
     return bb_reader
 
 
 @pytest.fixture()
 def bw_reader(bigwig):
+    """Provide a pyBigWig reader opened on a bigWig file path."""
     bw_reader = pyBigWig.open(bigwig)
     return bw_reader

--- a/datachecks/helper.py
+++ b/datachecks/helper.py
@@ -16,6 +16,15 @@ import logging
 
 
 def logAssert(test, msg):
+    """Log a pass/fail message according to the boolean test.
+
+    Args:
+        test (bool): Condition that indicates pass (True) or fail (False).
+        msg (str): Message to include in the log.
+
+    Returns:
+        None
+    """
     if not test:
         logging.error("FAILED:", msg)
     else:

--- a/datachecks/run_datachecks.py
+++ b/datachecks/run_datachecks.py
@@ -31,6 +31,16 @@ logger.setLevel(logging.INFO)
 
 
 def parse_args(args=None):
+    """Parse command-line arguments for running datachecks.
+
+    Args:
+        args (list|None): List of arguments to parse (for testing). If None, argparse
+            reads from sys.argv.
+
+    Returns:
+        argparse.Namespace: Parsed arguments with attributes such as dir, input_config,
+            output_dir, memory, time, partition, mail_user and tests.
+    """
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--dir", dest="dir", type=str, default=os.getcwd())
@@ -55,6 +65,19 @@ def parse_args(args=None):
 
 
 def get_species_metadata(input_config: str = None) -> dict:
+    """Load species metadata mapping from a JSON configuration file.
+
+    The returned mapping uses genome UUIDs as keys and maps to a dict containing
+    'species', 'assembly' and 'file_location'.
+
+    Args:
+        input_config (str|None): Path to JSON input configuration file. If None or
+            the file does not exist, the function returns an empty list.
+
+    Returns:
+        dict|list: Mapping {genome_uuid: {species, assembly, file_location}} or an
+            empty list if the input file is missing or invalid.
+    """
     if input_config is None or not os.path.isfile(input_config):
         return []
 
@@ -76,6 +99,15 @@ def get_species_metadata(input_config: str = None) -> dict:
 
 
 def is_valid_uuid(uuid: str):
+    """Validate whether a string is a canonical UUID.
+
+    Args:
+        uuid (str): Candidate UUID string.
+
+    Returns:
+        bool: True if the string is a valid UUID and matches its canonical representation,
+            False otherwise.
+    """
     try:
         uuid_obj = UUID(uuid)
     except ValueError:
@@ -84,6 +116,19 @@ def is_valid_uuid(uuid: str):
 
 
 def main(args=None):
+    """Main entry point to submit datachecks jobs.
+
+    Parses arguments, optionally loads species metadata, scans api and track output
+    directories for genome UUIDs and submits a job (sbatch) that runs pytest for each
+    detected genome, writing per-species sbatch wrapper scripts.
+
+    Args:
+        args (list|None): Optional list of arguments for testing; if None parsed from
+            sys.argv.
+
+    Returns:
+        None
+    """
     args = parse_args(args)
 
     input_config = args.input_config or None

--- a/datachecks/test_bigbed.py
+++ b/datachecks/test_bigbed.py
@@ -20,14 +20,24 @@ import random
 
 class TestFile:
     def test_exist(self, bigbed):
+        """Assert that the bigBed file exists on disk."""
         assert os.path.isfile(bigbed)
 
     def test_validity(self, bb_reader):
+        """Assert that the reader recognises the file as BigBed."""
         assert bb_reader.isBigBed()
 
 
 class TestSrcCount:
     def get_total_variant_count_from_vcf(self, vcf: str) -> int:
+        """Return number of VCF records using bcftools.
+
+        Args:
+            vcf (str): Path to VCF file.
+
+        Returns:
+            int: Number of records or -1 on failure.
+        """
         if vcf is None:
             logger.warning(f"Could not get variant count - no file provided")
             return -1
@@ -45,12 +55,21 @@ class TestSrcCount:
         return int(process.stdout.decode().strip())
 
     def get_total_variant_count_from_bb(self, bb_reader) -> int:
+        """Count entries across all chromosomes in a bigBed reader.
+
+        Args:
+            bb_reader: bigBed reader instance.
+
+        Returns:
+            int: Total number of entries.
+        """
         variant_counts = 0
         for chr in bb_reader.chroms():
             variant_counts += len(bb_reader.entries(chr, 0, bb_reader.chroms(chr)))
         return variant_counts
 
     def test_compare_count_with_source(self, vcf, bb_reader):
+        """Compare approximate counts between VCF and bigBed-derived counts."""
         variant_count_vcf = self.get_total_variant_count_from_vcf(vcf)
         variant_count_bb = self.get_total_variant_count_from_bb(bb_reader)
 
@@ -59,6 +78,7 @@ class TestSrcCount:
 
 class TestSrcExistence:
     def test_variant_exist_from_source(self, bb_reader, vcf_reader):
+        """Sample variants from VCF and ensure corresponding bigBed entries exist and include IDs."""
         NO_VARIANTS = 100
         NO_ITER = 100000
 

--- a/datachecks/test_bigwig.py
+++ b/datachecks/test_bigwig.py
@@ -20,14 +20,17 @@ import random
 
 class TestFile:
     def test_exist(self, bigwig):
+        """Assert that the bigWig file exists on disk."""
         assert os.path.isfile(bigwig)
 
     def test_validity(self, bw_reader):
+        """Assert that the reader recognises the file as BigWig."""
         assert bw_reader.isBigWig()
 
 
 class TestSrcExistence:
     def test_variant_exist_from_source(self, bw_reader, vcf_reader):
+        """Sample variants from VCF and ensure BigWig has non-zero scores at those positions."""
         NO_VARIANTS = 100
         NO_ITER = 100000
 
@@ -56,6 +59,14 @@ class TestSrcExistence:
 
 class TestSrcCount:
     def get_total_variant_count_from_vcf(self, vcf: str) -> int:
+        """Return the number of records in a VCF using bcftools index --nrecords.
+
+        Args:
+            vcf (str): Path to VCF file.
+
+        Returns:
+            int: Number of records, or -1 on failure.
+        """
         if vcf is None:
             logger.warning(f"Could not get variant count - no file provided")
             return -1
@@ -73,6 +84,14 @@ class TestSrcCount:
         return int(process.stdout.decode().strip())
 
     def get_total_variant_count_from_bw(self, bw_reader) -> int:
+        """Count non-zero value positions across all chromosomes in a BigWig.
+
+        Args:
+            bw_reader: pyBigWig reader instance.
+
+        Returns:
+            int: Count of positions with value > 0.0.
+        """
         variant_counts = 0
         for chr in bw_reader.chroms():
             non_zero_vals = [
@@ -84,6 +103,7 @@ class TestSrcCount:
         return variant_counts
 
     def test_compare_count_with_source(self, vcf, bw_reader):
+        """Compare approximate variant counts between source VCF and BigWig-derived counts."""
         variant_count_vcf = self.get_total_variant_count_from_vcf(vcf)
         variant_count_bw = self.get_total_variant_count_from_bw(bw_reader)
 

--- a/nextflow/vcf_prepper/bin/generate_chrom_sizes.py
+++ b/nextflow/vcf_prepper/bin/generate_chrom_sizes.py
@@ -24,6 +24,14 @@ from helper import parse_ini, get_db_name
 
 
 def parse_args(args=None):
+    """Parse command-line arguments for generate_chrom_sizes.
+
+    Args:
+        args (list|None): Optional argument list for testing.
+
+    Returns:
+        argparse.Namespace: Parsed arguments.
+    """
     parser = argparse.ArgumentParser()
 
     parser.add_argument(dest="species", type=str, help="species production name")
@@ -61,6 +69,21 @@ def generate_chrom_sizes(
     assembly: str = "grch38",
     force: bool = False,
 ) -> None:
+    """Generate a chromosome sizes file from the core database.
+
+    Writes seq_region lengths and synonym lengths, deduplicates and ensures lengths
+    are incremented by one to accommodate downstream tools.
+
+    Args:
+        server (dict): Server connection mapping.
+        core_db (str): Core database name.
+        chrom_sizes (str): Output chrom sizes filename.
+        assembly (str): Assembly identifier used to filter coord_system.
+        force (bool): If True overwrite existing file.
+
+    Returns:
+        None
+    """
     if os.path.exists(chrom_sizes) and not force:
         print(f"[INFO] {chrom_sizes} file already exists, skipping ...")
         return
@@ -152,6 +175,16 @@ def generate_chrom_sizes(
 
 
 def main(args=None):
+    """Main entry point to create chromosome sizes file.
+
+    Parses arguments, determines the core DB and invokes generate_chrom_sizes.
+
+    Args:
+        args (list|None): Optional argument list for testing.
+
+    Returns:
+        None
+    """
     args = parse_args(args)
 
     species = args.species

--- a/nextflow/vcf_prepper/bin/generate_chrom_sizes.py
+++ b/nextflow/vcf_prepper/bin/generate_chrom_sizes.py
@@ -71,8 +71,7 @@ def generate_chrom_sizes(
 ) -> None:
     """Generate a chromosome sizes file from the core database.
 
-    Writes seq_region lengths and synonym lengths, deduplicates and ensures lengths
-    are incremented by one to accommodate downstream tools.
+    Writes seq_region lengths and synonym lengths with deduplication.
 
     Args:
         server (dict): Server connection mapping.

--- a/nextflow/vcf_prepper/bin/generate_synonym_file.py
+++ b/nextflow/vcf_prepper/bin/generate_synonym_file.py
@@ -24,6 +24,14 @@ from helper import parse_ini, get_db_name
 
 
 def parse_args(args=None):
+    """Parse command-line arguments for generate_synonym_file.
+
+    Args:
+        args (list|None): Optional argument list for testing; if None uses sys.argv.
+
+    Returns:
+        argparse.Namespace: Parsed arguments.
+    """
     parser = argparse.ArgumentParser()
 
     parser.add_argument(dest="species", type=str, help="species production name")
@@ -57,6 +65,20 @@ def parse_args(args=None):
 def generate_synonym_file(
     server: dict, core_db: str, synonym_file: str, force: bool = False
 ) -> None:
+    """Generate a chromosome synonym file from the core database.
+
+    Queries seq_region and seq_region_synonym tables, post-processes to remove duplicates
+    and resolves names longer than 31 characters where possible.
+
+    Args:
+        server (dict): Server connection mapping.
+        core_db (str): Core database name.
+        synonym_file (str): Output file path.
+        force (bool): If True overwrite existing file, otherwise skip if exists.
+
+    Returns:
+        None
+    """
     if os.path.exists(synonym_file) and not force:
         print(f"[INFO] {synonym_file} file already exists, skipping ...")
         return
@@ -130,6 +152,16 @@ def generate_synonym_file(
 
 
 def main(args=None):
+    """Main entry point to create a synonyms file.
+
+    Parses arguments, determines the core database and invokes generate_synonym_file.
+
+    Args:
+        args (list|None): Optional argument list for testing.
+
+    Returns:
+        None
+    """
     args = parse_args(args)
 
     species = args.species

--- a/nextflow/vcf_prepper/bin/generate_vep_config.py
+++ b/nextflow/vcf_prepper/bin/generate_vep_config.py
@@ -179,7 +179,7 @@ def format_custom_args(
 ) -> str:
     """Format a custom annotation argument line for VEP.
 
-    Validates that files matching the file pattern exist (supports placeholder ###CHR###)
+    Validates that files matching the file pattern exist (supports placeholder, e.g. - ###CHR###)
     and returns a single-line 'custom' configuration for the VEP ini.
 
     Args:
@@ -214,7 +214,7 @@ def get_frequency_args(
     """Construct VEP custom arguments for population frequency resources.
 
     Parses the provided population JSON and constructs custom lines for each population
-    data file. Also adds 1kg frequency entry for human species.
+    data file.
 
     Args:
         population_data_file (str): Path to population JSON file.

--- a/nextflow/vcf_prepper/bin/process_cache.py
+++ b/nextflow/vcf_prepper/bin/process_cache.py
@@ -28,6 +28,15 @@ CACHE_DIR = "/nfs/production/flicek/ensembl/variation/data/VEP/tabixconverted"
 
 
 def parse_args(args=None):
+    """Parse command-line arguments for cache processing.
+
+    Args:
+        args (list|None): Optional argument list for testing.
+
+    Returns:
+        argparse.Namespace: Parsed arguments including species, assembly, version, division,
+            ini_file, cache_dir and force flag.
+    """
     parser = argparse.ArgumentParser()
 
     parser.add_argument(dest="species", type=str, help="species production name")
@@ -61,6 +70,15 @@ def parse_args(args=None):
 
 
 def uncompress_cache(cache_dir: str, compressed_cache: str) -> None:
+    """Unpack a compressed VEP cache tarball into the cache directory.
+
+    Args:
+        cache_dir (str): Destination directory to extract into.
+        compressed_cache (str): Path to the compressed tar.gz cache file.
+
+    Raises:
+        SystemExit: Exits with non-zero status if the tar extraction fails.
+    """
     process = subprocess.run(
         ["tar", "-xvzf", compressed_cache, "-C", cache_dir],
         stdout=subprocess.PIPE,
@@ -73,6 +91,17 @@ def uncompress_cache(cache_dir: str, compressed_cache: str) -> None:
 
 
 def main(args=None):
+    """Main entry point for processing VEP cache archives.
+
+    Locates cache files (local or remote), downloads if necessary, and unpacks the cache
+    into the expected directory structure.
+
+    Args:
+        args (list|None): Optional argument list for testing; if None uses sys.argv.
+
+    Returns:
+        None
+    """
     args = parse_args(args)
 
     species = args.species

--- a/nextflow/vcf_prepper/bin/process_conservation_data.py
+++ b/nextflow/vcf_prepper/bin/process_conservation_data.py
@@ -29,6 +29,15 @@ CONSERVATION_DATA_DIR = "/nfs/production/flicek/ensembl/variation/data/Conservat
 
 
 def parse_args(args=None):
+    """Parse command-line arguments for conservation data processing.
+
+    Args:
+        args (list|None): Optional argument list for testing.
+
+    Returns:
+        argparse.Namespace: Parsed arguments including species, assembly, version, division,
+            ini_file, conservation_data_dir and force flag.
+    """
     parser = argparse.ArgumentParser()
 
     parser.add_argument(dest="species", type=str, help="species production name")
@@ -62,6 +71,17 @@ def parse_args(args=None):
 
 
 def main(args=None):
+    """Main entry point to ensure conservation bigWig data is available.
+
+    Determines the expected conservation bigWig location, attempts to copy from local
+    FTP or download from remote FTP, and honours the 'force' flag to overwrite existing files.
+
+    Args:
+        args (list|None): Optional argument list for testing; if None uses sys.argv.
+
+    Returns:
+        None
+    """
     args = parse_args(args)
 
     species = args.species

--- a/nextflow/vcf_prepper/bin/process_fasta.py
+++ b/nextflow/vcf_prepper/bin/process_fasta.py
@@ -31,6 +31,15 @@ FASTA_FILE_NAME = "unmasked.fa.gz"
 
 
 def parse_args(args=None):
+    """Parse command-line arguments for processing FASTA files.
+
+    Args:
+        args (list|None): Optional argument list for testing.
+
+    Returns:
+        argparse.Namespace: Parsed arguments including species, genome_uuid, assembly,
+            version, out_dir, division, ini_file, fasta_dir, use_old_infra and force.
+    """
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
@@ -85,6 +94,18 @@ def parse_args(args=None):
 
 
 def index_fasta(bgzipped_fasta: str, force: str = False) -> None:
+    """Index a bgzipped FASTA file, creating .fai and .gzi files.
+
+    Uses a Perl HTS::Faidx call to create indices. If index files already exist and
+    force is False the function does nothing.
+
+    Args:
+        bgzipped_fasta (str): Path to bgzipped FASTA file.
+        force (bool): If False and index files exist, skip indexing.
+
+    Raises:
+        SystemExit: Exits with error code 1 if indexing fails.
+    """
     if not os.path.isfile(bgzipped_fasta):
         FileNotFoundError(
             f"Cannot index fasta. File does not exist - {bgzipped_fasta}."
@@ -120,6 +141,17 @@ def index_fasta(bgzipped_fasta: str, force: str = False) -> None:
 
 
 def main(args=None):
+    """Main entry point for processing FASTA files for VEP.
+
+    Handles both 'old infra' and 'new infra' modes: copies or downloads FASTA files,
+    (un)compresses, bgzips and indexes them as needed.
+
+    Args:
+        args (list|None): Optional argument list for testing; if None uses sys.argv.
+
+    Returns:
+        None
+    """
     args = parse_args(args)
 
     out_dir = args.out_dir or os.getcwd()

--- a/nextflow/vcf_prepper/bin/process_gff.py
+++ b/nextflow/vcf_prepper/bin/process_gff.py
@@ -29,6 +29,15 @@ GFF_FILE_NAME = "sorted_genes.gff3.gz"
 
 
 def parse_args(args=None):
+    """Parse command-line arguments for processing a GFF.
+
+    Args:
+        args (list|None): Optional argument list for testing.
+
+    Returns:
+        argparse.Namespace: Parsed arguments including genome_uuid, release_id, out_dir,
+            ini_file, gff_dir and force flag.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument(dest="genome_uuid", type=str, help="Genome uuid")
     parser.add_argument(
@@ -57,6 +66,16 @@ def parse_args(args=None):
 
 
 def index_gff(bgzipped_gff: str, force: str = False) -> None:
+    """Create a CSI index for a bgzipped GFF file using tabix.
+
+    Args:
+        bgzipped_gff (str): Path to the bgzipped GFF file.
+        force (bool): If False and a .csi exists, skip indexing.
+
+    Raises:
+        FileNotFoundError: If the GFF file does not exist.
+        SystemExit: Exits with error code 1 if tabix indexing fails.
+    """
     if not os.path.isfile(bgzipped_gff):
         raise FileNotFoundError(
             f"Could not run tabix index. File does not exist - {bgzipped_gff}"
@@ -81,6 +100,19 @@ def index_gff(bgzipped_gff: str, force: str = False) -> None:
 
 
 def sort_gff(file: str, sorted_file: str = None) -> str:
+    """Sort a GFF file by seqname and start/end positions while preserving header lines.
+
+    Args:
+        file (str): Path to the input GFF file.
+        sorted_file (str|None): Optional output path for the sorted file. If omitted,
+            a file named "sorted_<basename>" is created in the same directory.
+
+    Returns:
+        str: Path to the sorted file.
+
+    Raises:
+        FileNotFoundError: If the input file does not exist.
+    """
     if not os.path.isfile(file):
         raise FileNotFoundError(f"Could not sort. File does not exist - {file}")
 
@@ -96,6 +128,17 @@ def sort_gff(file: str, sorted_file: str = None) -> str:
 
 
 def main(args=None):
+    """Main entry point for processing and indexing a GFF for a genome.
+
+    Uses metadata to locate the appropriate GFF source when necessary, copies, sorts,
+    bgzips and indexes the GFF file.
+
+    Args:
+        args (list|None): Optional argument list for testing; if None uses sys.argv.
+
+    Returns:
+        None
+    """
     args = parse_args(args)
 
     genome_uuid = args.genome_uuid

--- a/nextflow/vcf_prepper/bin/remove_variants.py
+++ b/nextflow/vcf_prepper/bin/remove_variants.py
@@ -148,8 +148,7 @@ def parse_chrom_sizes(chrom_sizes: str) -> list:
 def main(args=None):
     """Main entry point for remove_variants script.
 
-    Parses arguments, determines which identifiers should be removed and writes a processed
-    VCF excluding those variants (and optionally filtering chromosomes).
+    Process a VCF and write a new one removing variant lines on different criteria.
 
     Args:
         args (list|None): Optional list of arguments for testing; if None uses sys.argv.

--- a/nextflow/vcf_prepper/bin/summary_stats.py
+++ b/nextflow/vcf_prepper/bin/summary_stats.py
@@ -92,6 +92,15 @@ SKIP_CONSEQUENCE = [
 
 
 def parse_args(args=None, description: bool = None):
+    """Parse command-line arguments for summary_stats.
+
+    Args:
+        args (list|None): Argument list to parse (for testing). If None, argparse reads from sys.argv.
+        description (str|None): Optional description for the ArgumentParser.
+
+    Returns:
+        argparse.Namespace: Parsed arguments.
+    """
     parser = argparse.ArgumentParser(description=description)
 
     parser.add_argument(dest="species", type=str, help="species production name")
@@ -109,6 +118,18 @@ def parse_args(args=None, description: bool = None):
 
 
 def header_match(want_header: dict, got_header: dict) -> bool:
+    """Compare a desired INFO header entry with an existing VCF header entry.
+
+    The function removes the 'IDX' key from the obtained header before performing
+    the comparison of ID, Type, Number and Description.
+
+    Args:
+        want_header (dict): Desired header specification.
+        got_header (dict): Header entry returned by cyvcf2 for a key.
+
+    Returns:
+        bool: True if the headers match, False otherwise.
+    """
     got_header.pop("IDX")
 
     return (
@@ -120,6 +141,18 @@ def header_match(want_header: dict, got_header: dict) -> bool:
 
 
 def minimise_allele(ref: str, alts: list) -> str:
+    """Minimise allele representation by trimming a common leading base.
+
+    If all alleles share the same first base, remove it from REF and ALT alleles; an empty
+    allele becomes '-' to preserve representation.
+
+    Args:
+        ref (str): Reference allele.
+        alts (list): List of alternate alleles.
+
+    Returns:
+        tuple: (minimised_ref, minimised_alts) where minimised_alts is a list of strings.
+    """
     alleles = [ref] + alts
     first_bases = {allele[0] for allele in alleles}
 
@@ -138,6 +171,18 @@ def minimise_allele(ref: str, alts: list) -> str:
 
 
 def main(args=None):
+    """Compute and add summary INFO fields to VCF records.
+
+    Parses arguments, optionally loads representative population configuration and then
+    iterates through VCF records to compute summary tags (e.g. NTCSQ, RAF) based on CSQ
+    annotations and writes the updated records to the output VCF.
+
+    Args:
+        args (list|None): Optional list of arguments for testing; if None uses sys.argv.
+
+    Returns:
+        None
+    """
     args = parse_args(args)
 
     species = args.species

--- a/nextflow/vcf_prepper/bin/update_fields.py
+++ b/nextflow/vcf_prepper/bin/update_fields.py
@@ -33,6 +33,16 @@ VARIATION_SOURCE_DUMP_FILENAME = "variation_source.txt"
 
 
 def parse_args(args=None, description: bool = None):
+    """Parse command-line arguments for update_fields.
+
+    Args:
+        args (list|None): List of arguments to parse (for testing). If None, argparse will
+            read from sys.argv.
+        description (str|None): Optional description to use for the ArgumentParser.
+
+    Returns:
+        argparse.Namespace: Parsed arguments.
+    """
     parser = argparse.ArgumentParser(description=description)
 
     parser.add_argument(dest="input_file", type=str, help="Input VCF file")
@@ -68,6 +78,17 @@ def parse_args(args=None, description: bool = None):
 
 
 def format_clinvar_id(id: str) -> str:
+    """Format a ClinVar identifier to the canonical VCV style.
+
+    If the identifier is numeric or does not already start with 'VCV', this function pads
+    with leading zeros and prefixes 'VCV' to produce the standard identifier.
+
+    Args:
+        id (str): Input ClinVar identifier (numeric string or already-formatted).
+
+    Returns:
+        str: Formatted ClinVar identifier starting with 'VCV'.
+    """
     if not id.startswith("VCV"):
         leading_zero = 9 - len(id)
         return "VCV" + ("0" * leading_zero) + id
@@ -76,6 +97,16 @@ def format_clinvar_id(id: str) -> str:
 
 
 def format_meta(meta: str, chromosomes: str = None, synonyms: list = None) -> str:
+    """Append contig meta lines for the requested chromosomes.
+
+    Args:
+        meta (str): Existing meta header text.
+        chromosomes (str|None): Comma-separated chromosome names to include as contigs.
+        synonyms (dict|None): Mapping of chromosome names to synonyms.
+
+    Returns:
+        str: Updated meta header including contig lines if chromosomes provided.
+    """
     if chromosomes is None:
         return meta
 
@@ -86,6 +117,14 @@ def format_meta(meta: str, chromosomes: str = None, synonyms: list = None) -> st
 
 
 def process_variant_source() -> dict:
+    """Load a mapping of variant name to source from a dump file.
+
+    Reads the file named VARIATION_SOURCE_DUMP_FILENAME and returns a dictionary that maps
+    variant names to their source.
+
+    Returns:
+        dict: Mapping variant_name -> source.
+    """
     variant_source = {}
     with open(VARIATION_SOURCE_DUMP_FILENAME, "r") as file:
         for line in file:
@@ -96,6 +135,17 @@ def process_variant_source() -> dict:
 
 
 def main(args=None):
+    """Main entry point for update_fields script.
+
+    Parses arguments, reads an input VCF, rewrites selected INFO fields and writes a
+    simplified, bgzf-compressed VCF with updated header and INFO tags.
+
+    Args:
+        args (list|None): Optional list of arguments for testing; if None uses sys.argv.
+
+    Returns:
+        None
+    """
     args = parse_args(args)
 
     input_file = args.input_file

--- a/nextflow/vcf_prepper/bin/update_fields.py
+++ b/nextflow/vcf_prepper/bin/update_fields.py
@@ -97,7 +97,7 @@ def format_clinvar_id(id: str) -> str:
 
 
 def format_meta(meta: str, chromosomes: str = None, synonyms: list = None) -> str:
-    """Append contig meta lines for the requested chromosomes.
+    """Append contig meta header lines for the requested chromosomes.
 
     Args:
         meta (str): Existing meta header text.

--- a/scripts/population_to_haplotype.py
+++ b/scripts/population_to_haplotype.py
@@ -37,6 +37,14 @@ args = parser.parse_args()
 
 
 def get_sample_genotype_prefix(sample):
+    """Return genotype prefix mapping for a sample.
+
+    Args:
+        sample (str): Sample name.
+
+    Returns:
+        dict: Mapping from genotype index to string prefix (e.g. {0: 'paternal', 1: 'maternal'}).
+    """
     if sample == "GRCh38":
         return {0: "GCA_000001405.29"}
     else:
@@ -44,6 +52,16 @@ def get_sample_genotype_prefix(sample):
 
 
 def generate_filenames(sample, split_sv):
+    """Generate output filenames for each genotype and variant type.
+
+    Args:
+        sample (str): Sample name used as filename prefix.
+        split_sv (bool): Whether to split short and structural variants into separate files.
+
+    Returns:
+        dict: Dictionary with keys "short_variant" and "structural_variant" each mapping genotype
+            indices to filenames.
+    """
     genotype_prefix = get_sample_genotype_prefix(sample)
     output_files = {
         gt_idx: f"{sample}_{prefix}.vcf" for gt_idx, prefix in genotype_prefix.items()
@@ -67,6 +85,18 @@ def generate_filenames(sample, split_sv):
 
 
 def bgzip_file(file: str) -> bool:
+    """Compress a file using bgzip and raise on failure.
+
+    Args:
+        file (str): Path to the file to compress.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        Exception: If bgzip returns a non-zero exit code.
+
+    Returns:
+        bool: Nothing is explicitly returned; function may raise on error.
+    """
     if not os.path.isfile(file):
         raise FileNotFoundError(f"File not found - {file}")
 
@@ -76,6 +106,18 @@ def bgzip_file(file: str) -> bool:
 
 
 def index_file(file: str) -> bool:
+    """Create a tabix index for a VCF file and raise on failure.
+
+    Args:
+        file (str): Path to the VCF file to index.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        Exception: If tabix returns a non-zero exit code.
+
+    Returns:
+        bool: Nothing is explicitly returned; function may raise on error.
+    """
     if not os.path.isfile(file):
         raise FileNotFoundError(f"File not found - {file}")
 

--- a/scripts/test_track_api_endpoint.py
+++ b/scripts/test_track_api_endpoint.py
@@ -22,6 +22,15 @@ import json
 
 
 def fetch_data(url):
+    """Fetch JSON data from a URL using HTTP GET.
+
+    Args:
+        url (str): URL to request.
+
+    Returns:
+        dict|list|None: Parsed JSON response if the request and parsing succeed,
+            otherwise None on any RequestException.
+    """
     try:
         response = requests.get(url)
         response.raise_for_status()
@@ -32,6 +41,19 @@ def fetch_data(url):
 
 
 def main(argv):
+    """Validate track API endpoints against a local track metadata file.
+
+    Reads a track metadata JSON file, queries the remote /track_categories and /track
+    API endpoints for each genome UUID and compares returned values (label, description,
+    datafile names) with the expected values from the metadata file. Prints mismatches.
+
+    Args:
+        argv (list): Command-line argument vector; argv[1] should be the path to the
+            track metadata JSON file.
+
+    Raises:
+        FileNotFoundError: If the provided track metadata file does not exist.
+    """
     track_metadata_file = argv[1]
     if not os.path.isfile(track_metadata_file):
         raise FileNotFoundError(


### PR DESCRIPTION
This PR affects all *.py files (that contain functions) in the repo.

For every function, either a Google-style docstring is added, or an existing docstring is improved and coerced into Google-style.

To do this I used VSCode + GitHub Copilot:

I used Copilot in 'Edit' mode with ChatGPT 5-mini (Preview).
For each directory containing .py files, I set the 'context' as the directory's path, and found that the following prompt delivered the best results:

> For all .py files:
> For functions with no docstring, analyse the function and add a suitable Google-style docstring. If the function has a docstring, improve it and coerce it into a Google-style docstring. Do not change any code or code formatting. Use UK English.

I then scanned through each suggestion and accepted if it was sensible and contextually correct.