### PR TITLE
stabilise nf-test workflow on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: setup
-        run: curl -fsSL https://code.askimed.com/install/nf-test | bash
+        run: curl -fsSL https://get.nf-test.com | bash -s 0.9.2
       - name: test
         run: ${GITHUB_WORKSPACE}/nf-test test nextflow/vcf_prepper/tests


### PR DESCRIPTION
Trivial first PR - just setting a fixed version for nf-test for the integration of this set of PRs. 0.92 seems to be the last stable that support coverage command instead of status.

We can update the code to support status instead later and increment the nf-test version, but these seemed simpler for now.