### PR TITLE
Fix: nextflow module import path resolution.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 **/.nf-test
 **/__pycache__
 **/.python-version
+
+#Path for external nextflow module linkage
+external-imports/

--- a/nextflow/Makefile
+++ b/nextflow/Makefile
@@ -1,3 +1,5 @@
+ENS_REPO_PATH=../../../ensembl-vep/
+
 clean:
 	rm -rf external-imports/
 
@@ -5,4 +7,4 @@ external-imports/:
 	mkdir external-imports/
 
 external-imports/ensembl-vep: external-imports/
-	ln -s ../../../ensembl-vep/ external-imports/ensembl-vep
+	ln -s ${ENS_REPO_PATH} external-imports/ensembl-vep

--- a/nextflow/Makefile
+++ b/nextflow/Makefile
@@ -4,7 +4,7 @@ clean:
 	rm -rf external-imports/
 
 external-imports/:
-	mkdir external-imports/
+	mkdir -p external-imports/
 
 external-imports/ensembl-vep: external-imports/
-	ln -s ${ENS_REPO_PATH} external-imports/ensembl-vep
+	ln -fns ${ENS_REPO_PATH} external-imports/ensembl-vep

--- a/nextflow/Makefile
+++ b/nextflow/Makefile
@@ -1,0 +1,8 @@
+clean:
+	rm -rf external-imports/
+
+external-imports/:
+	mkdir external-imports/
+
+external-imports/ensembl-vep: external-imports/
+	ln -s ../../../ensembl-vep/ external-imports/ensembl-vep

--- a/nextflow/vcf_prepper/subworkflows/local/run_vep.nf
+++ b/nextflow/vcf_prepper/subworkflows/local/run_vep.nf
@@ -13,20 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 //
 // run VEP annotation
 //
 
-repo_dir = params.repo_dir
-
 include { INDEX_VCF } from "../../modules/local/index_vcf.nf"
-include { vep } from "${repo_dir}/ensembl-vep/nextflow/workflows/run_vep.nf"
+include { vep } from "../../../external-imports/ensembl-vep/nextflow/workflows/run_vep.nf"
 
 workflow RUN_VEP {
   take:
     input
-  
+
   main:
   // create index file at the exact location where input vcf file is as nextflow-vep requires as such
   input


### PR DESCRIPTION
Prior to this PR, running a vcf_prepper pipeline would fail to import the vep-repo nextflow workflows if the directory was not in the default `/hps/software/users/ensembl/variation/${USER}/ensembl-vep` location, even when using the `--repo_dir` CLI argument to overwrite the default. This is because params do not resolve on workflow parsing (when the imports are resolved) but only on execution (when the CLI params are processed). As a consequence, the repo_dir used to resolve the import would always be the hardcoded default from the `nextflow.config` file.

With this PR, you need to create a symlink called `nextflow/external-imports/ensembl-vep` in this repo dir to point to the directory containing the VEP code you want to use. In the assumption the VEP repo dir can be found in the same parent dir as this repository, you can call `make external-imports/ensembl-vep` using the `nextflow` dir as working dir to create this symlink prior to pipeline execution. For cleanup afterwards, one can call `make clean`.