### PR TITLE
Fix/eva data retrieval

### DIFF
--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -341,7 +341,11 @@ def get_eva_version_from_ensembl_vcf(vcf_path: str):
 
     path = Path(vcf_path)
     if not path.exists():
-        raise FileNotFoundError(vcf_path)
+       	new_prefix = "/lts/production/mfreeberg/variation/new_website_production/"
+       	new_path = Path("/".join([new_prefix] + vcf_path.split("/")[7:]))
+       	path = new_path
+       	if not path.exists():
+            raise FileNotFoundError(vcf_path)
 
     opener = gzip.open if path.suffix == ".gz" else open
     src_re = re.compile(r'##source=.*?EVA.*?version="([^"]+)"')

--- a/scripts/auto_create_input_config.py
+++ b/scripts/auto_create_input_config.py
@@ -139,13 +139,13 @@ def get_ensembl_species(server: dict, meta_db: str) -> dict:
     """
 
     query = f"""
-            SELECT 
-                g.genome_uuid, 
-                g.production_name, 
-                a.accession, 
-                a.assembly_default 
-            FROM genome AS g, assembly AS a 
-            WHERE g.assembly_id = a.assembly_id
+            SELECT
+               	g.genome_uuid,
+               	g.production_name,
+               	a.accession,
+               	a.assembly_default
+               	FROM genome AS g, assembly AS a, genome_release AS gr
+                WHERE g.assembly_id = a.assembly_id AND g.genome_id = gr.genome_id AND gr.is_current = 1
             """
 
     process = subprocess.run(


### PR DESCRIPTION
The data json generator running as a cron has been failing recently.
Failure reason was because function beginning at line 342 was looking for files that we moved to LTS.

Best fix is to replace this function with retrieving this data from metadata API, but it's not currently loaded there (will be added in future). Temporary fix to get the script working is to add a check on equivalent LTS dir before failing with can't find file error.

NB: Requires script to be run form datamover

To test:
`pyenv local variation-eva`
`srun --partition=datamover --nodes=1 --ntasks-per-node=1 --mem=2GB --time=12:00:00 --pty bash -i `(or salloc equivalent)
`python auto_create_input_config.py -I config.ini -O [output_dir] --tmp_dir [tmp dir] &> test.log`

config.ini to contain:

```
[metadata]
host=mysql-ens-meta-prod-1
port=4483
user=ensro
name=ensembl_genome_metadata
```

Config I used has this in as well, don't think it's required though:

```
[core]
host=mysql-ens-var-prod-3
port=4606
user=ensro
name=homo_sapiens_core_115_38
```

While fixing and running tests, I realised that the metadata DB query to retrieve species was not filtering to only include current releases, so there were duplicates or more copies of certain species being generated. Updated the query to also require genome_release.is_current = 1

